### PR TITLE
Add lowering pass, runtime, and backend to experiment with matmul kernels.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,13 +163,6 @@ if(MLIR_ENABLE_BINDINGS_PYTHON)
   mlir_configure_python_dev_packages()
 endif()
 
-add_subdirectory(include)
-add_subdirectory(lib)
-add_subdirectory(tools)
-
-add_custom_target(check-torch-mlir-all)
-add_dependencies(check-torch-mlir-all check-torch-mlir)
-
 if(MLIR_ENABLE_BINDINGS_PYTHON)
   # If parent projects want to configure where to place the python packages,
   # respect that.
@@ -177,6 +170,13 @@ if(MLIR_ENABLE_BINDINGS_PYTHON)
     set(TORCH_MLIR_PYTHON_PACKAGES_DIR "${CMAKE_CURRENT_BINARY_DIR}/python_packages")
   endif()
 endif()
+
+add_subdirectory(include)
+add_subdirectory(lib)
+add_subdirectory(tools)
+
+add_custom_target(check-torch-mlir-all)
+add_dependencies(check-torch-mlir-all check-torch-mlir)
 
 add_subdirectory(test)
 

--- a/include/torch-mlir/Conversion/LinalgToKernelCalls/LinalgToKernelCalls.h
+++ b/include/torch-mlir/Conversion/LinalgToKernelCalls/LinalgToKernelCalls.h
@@ -1,0 +1,25 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TORCHMLIR_CONVERSION_LINALGTOKERNELCALLS_LINALGTOKERNELCALLS_H
+#define TORCHMLIR_CONVERSION_LINALGTOKERNELCALLS_LINALGTOKERNELCALLS_H
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace mlir {
+namespace torch {
+std::unique_ptr<OperationPass<ModuleOp>>
+createConvertLinalgOpsToKernelCallsPass();
+}
+} // namespace mlir
+
+#endif // TORCHMLIR_CONVERSION_LINALGTOKERNELCALLS_LINALGTOKERNELCALLS_H

--- a/include/torch-mlir/Conversion/Passes.td
+++ b/include/torch-mlir/Conversion/Passes.td
@@ -154,4 +154,15 @@ def ConvertTorchToStablehlo : Pass<"convert-torch-to-stablehlo", "func::FuncOp">
 }
 #endif
 
+def ConvertLinalgOpsToKernelCalls
+    : Pass<"convert-linalg-ops-to-kernel-calls", "ModuleOp"> {
+  let summary = "Lower linalg.matmul operation to kernel call.";
+  let constructor = [{
+    mlir::torch::createConvertLinalgOpsToKernelCallsPass()
+  }];
+  let description = [{
+    This pass replaces linalg.matmul operations with calls to the runtime library.
+  }];
+}
+
 #endif // TORCHMLIR_CONVERSION_PASSES

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(CAPI)
 add_subdirectory(Conversion)
 add_subdirectory(Dialect)
+add_subdirectory(Runtime)
 
 set(LinkedLibs
   MLIRComplexDialect

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(LinalgToKernelCalls)
 add_subdirectory(TorchToLinalg)
 add_subdirectory(TorchToSCF)
 add_subdirectory(TorchToArith)
@@ -10,7 +11,8 @@ add_subdirectory(TorchConversionToMLProgram)
 add_subdirectory(Utils)
 
 # TODO: Automate this with add_torch_mlir_conversion_library.
-set(linked_libs TorchMLIRTorchToLinalg
+set(linked_libs TorchMLIRLinalgToKernelCalls
+                TorchMLIRTorchToLinalg
                 TorchMLIRTorchToSCF
                 TorchMLIRTorchToArith
                 TorchMLIRTorchToTosa

--- a/lib/Conversion/LinalgToKernelCalls/CMakeLists.txt
+++ b/lib/Conversion/LinalgToKernelCalls/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_mlir_conversion_library(TorchMLIRLinalgToKernelCalls
+  LinalgToKernelCalls.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/torch-mlir/Conversion/TorchToLinalg
+
+  DEPENDS
+  TorchMLIRConversionPassIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRLinalgDialect
+  MLIRMathDialect
+  TorchMLIRTorchDialect
+)
+
+torch_mlir_target_includes(TorchMLIRLinalgToKernelCalls)

--- a/lib/Conversion/LinalgToKernelCalls/LinalgToKernelCalls.cpp
+++ b/lib/Conversion/LinalgToKernelCalls/LinalgToKernelCalls.cpp
@@ -1,0 +1,126 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Conversion/LinalgToKernelCalls/LinalgToKernelCalls.h"
+
+#include "../PassDetail.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Complex/IR/Complex.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionDialect.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
+#include "torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
+
+#include <iostream>
+
+using namespace mlir;
+using namespace mlir::torch;
+using namespace mlir::torch::Torch;
+
+namespace {
+LogicalResult
+convertLinalgOpsInFunc(func::FuncOp func,
+                       std::map<std::string, SmallVector<Type>> &usedKernels) {
+  OpBuilder b(func.getBody());
+  SmallVector<Operation *> replacedOps;
+  func.walk([&](linalg::MatmulOp op) {
+    auto types = op.getOperandTypes();
+    auto lhs_type = types[0];
+    auto rhs_type = types[1];
+    auto res_type = types[2];
+    auto lhs_elem_type = lhs_type.cast<BaseMemRefType>().getElementType();
+    auto rhs_elem_type = rhs_type.cast<BaseMemRefType>().getElementType();
+    auto res_elem_type = res_type.cast<BaseMemRefType>().getElementType();
+
+    if (lhs_elem_type != rhs_elem_type || lhs_elem_type != res_elem_type)
+      return;
+
+    if (lhs_type.cast<BaseMemRefType>().getMemorySpace() !=
+            rhs_type.cast<BaseMemRefType>().getMemorySpace() ||
+        lhs_type.cast<BaseMemRefType>().getMemorySpace() !=
+            res_type.cast<BaseMemRefType>().getMemorySpace())
+      return;
+
+    if (!lhs_elem_type.isF16() && !lhs_elem_type.isF32() &&
+        !lhs_elem_type.isF64())
+      return;
+
+    b.setInsertionPoint(op);
+
+    auto unranked_type = UnrankedMemRefType::get(
+        lhs_elem_type, lhs_type.cast<BaseMemRefType>().getMemorySpace());
+    std::string fn_name = "matmul_kernel_";
+    llvm::raw_string_ostream rss(fn_name);
+    lhs_elem_type.print(rss);
+    if (!usedKernels.count(fn_name)) {
+      usedKernels.emplace(
+          fn_name,
+          SmallVector<Type>({unranked_type, unranked_type, unranked_type}));
+    }
+
+    SmallVector<Value> unranked_ops;
+    for (auto op : op.getOperands())
+      unranked_ops.push_back(
+          b.create<memref::CastOp>(op.getLoc(), unranked_type, op));
+    b.create<func::CallOp>(op.getLoc(), fn_name, TypeRange({}), unranked_ops);
+    replacedOps.push_back(op);
+  });
+
+  for (Operation *op : replacedOps)
+    op->erase();
+
+  return success();
+}
+} // namespace
+
+namespace {
+class ConvertLinalgOpsToKernelCalls
+    : public ConvertLinalgOpsToKernelCallsBase<ConvertLinalgOpsToKernelCalls> {
+public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect>();
+    registry.insert<math::MathDialect>();
+    registry.insert<func::FuncDialect>();
+    registry.insert<tensor::TensorDialect>();
+    registry.insert<arith::ArithDialect>();
+    registry.insert<cf::ControlFlowDialect>();
+    registry.insert<complex::ComplexDialect>();
+  }
+
+  void runOnOperation() override {
+    auto module = getOperation();
+    OpBuilder b(module.getBodyRegion());
+    std::map<std::string, SmallVector<Type>> usedKernels;
+    for (auto func : module.getOps<func::FuncOp>()) {
+      if (failed(convertLinalgOpsInFunc(func, usedKernels)))
+        return signalPassFailure();
+    }
+
+    // Create FuncOp for each used kernel function.
+    for (auto &p : usedKernels) {
+      auto kernelFunc = b.create<func::FuncOp>(
+          module.getLoc(), p.first,
+          FunctionType::get(module.getContext(), p.second, {}));
+      kernelFunc.setPrivate();
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::torch::createConvertLinalgOpsToKernelCallsPass() {
+  return std::make_unique<ConvertLinalgOpsToKernelCalls>();
+}

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -13,6 +13,7 @@
 #include "torch-mlir/Conversion/TorchToStablehlo/TorchToStablehlo.h"
 #endif // TORCH_MLIR_ENABLE_STABLEHLO
 
+#include "torch-mlir/Conversion/LinalgToKernelCalls/LinalgToKernelCalls.h"
 #include "torch-mlir/Conversion/TorchToLinalg/TorchToLinalg.h"
 #include "torch-mlir/Conversion/TorchToSCF/TorchToSCF.h"
 #include "torch-mlir/Conversion/TorchToArith/TorchToArith.h"

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(TorchMLIRKernels SHARED Kernels.cpp)
+
+set_target_properties(TorchMLIRKernels PROPERTIES
+         LIBRARY_OUTPUT_DIRECTORY "${TORCH_MLIR_PYTHON_PACKAGES_DIR}/torch_mlir/torch_mlir/_mlir_libs")

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -1,4 +1,10 @@
+find_package(MKL CONFIG REQUIRED)
+
 add_library(TorchMLIRKernels SHARED Kernels.cpp)
+
+target_compile_options(TorchMLIRKernels PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>)
+target_include_directories(TorchMLIRKernels PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>)
+target_link_libraries(TorchMLIRKernels PUBLIC $<LINK_ONLY:MKL::MKL>)
 
 set_target_properties(TorchMLIRKernels PROPERTIES
          LIBRARY_OUTPUT_DIRECTORY "${TORCH_MLIR_PYTHON_PACKAGES_DIR}/torch_mlir/torch_mlir/_mlir_libs")

--- a/lib/Runtime/Kernels.cpp
+++ b/lib/Runtime/Kernels.cpp
@@ -1,0 +1,62 @@
+#include <cstdint>
+#include <iostream>
+
+template <typename T> struct tensor {
+  T *buffer;         // Allocated memory, used for deallocation only
+  T *data;           // Aligned data.
+  int64_t offset;    // Offset (in elems) to the first element
+  int64_t rank[2];   // Shape in elems
+  int64_t stride[2]; // Strides in elems
+
+  T &ref(int64_t i, int64_t j) {
+    return *(data + i * stride[0] + j * stride[1]);
+  }
+};
+
+namespace {
+template <typename T>
+void test_matmul(int64_t lhs_rank, tensor<T> *lhs, int64_t rhs_rank,
+                 tensor<T> *rhs, int64_t res_rank, tensor<T> *res) {
+  std::cout << "test_matmul" << std::endl;
+  std::cout << "  lhs_rank=" << lhs_rank << std::endl
+            << "  rhs_rank=" << rhs_rank << std::endl
+            << "  res_rank=" << res_rank << std::endl;
+  std::cout << "  lhs={" << lhs->buffer << ", " << lhs->data << ", "
+            << lhs->offset << ", [" << lhs->rank[0] << ", " << lhs->rank[1]
+            << "], [" << lhs->stride[0] << ", " << lhs->stride[1] << "]}"
+            << std::endl;
+  std::cout << "  rhs={" << rhs->buffer << ", " << rhs->data << ", "
+            << rhs->offset << ", [" << rhs->rank[0] << ", " << rhs->rank[1]
+            << "], [" << rhs->stride[0] << ", " << rhs->stride[1] << "]}"
+            << std::endl;
+  std::cout << "  res={" << res->buffer << ", " << res->data << ", "
+            << res->offset << ", [" << res->rank[0] << ", " << res->rank[1]
+            << "], [" << res->stride[0] << ", " << res->stride[1] << "]}"
+            << std::endl;
+  for (int64_t i = 0; i < lhs->rank[0]; ++i) {
+    for (int64_t j = 0; j < rhs->rank[1]; ++j) {
+      for (int64_t k = 0; k < rhs->rank[0]; ++k) {
+        res->ref(i, j) += lhs->ref(i, k) * rhs->ref(k, j);
+      }
+    }
+  }
+}
+} // namespace
+
+// extern "C" void test_matmul_f16(int64_t lhs_rank, tensor<_Float16> *lhs,
+//                                 int64_t rhs_rank, tensor<_Float16> *rhs,
+//                                 int64_t res_rank, tensor<_Float16> *res) {
+//   test_matmul(lhs_rank, lhs, rhs_rank, rhs, res_rank, res);
+// }
+
+extern "C" void matmul_kernel_f32(int64_t lhs_rank, tensor<float> *lhs,
+                                  int64_t rhs_rank, tensor<float> *rhs,
+                                  int64_t res_rank, tensor<float> *res) {
+  test_matmul(lhs_rank, lhs, rhs_rank, rhs, res_rank, res);
+}
+
+extern "C" void matmul_kernel_f64(int64_t lhs_rank, tensor<double> *lhs,
+                                  int64_t rhs_rank, tensor<double> *rhs,
+                                  int64_t res_rank, tensor<double> *res) {
+  test_matmul(lhs_rank, lhs, rhs_rank, rhs, res_rank, res);
+}

--- a/projects/pt1/e2e_testing/main.py
+++ b/projects/pt1/e2e_testing/main.py
@@ -24,6 +24,7 @@ from torch_mlir_e2e_test.configs import (
 )
 
 from torch_mlir_e2e_test.linalg_on_tensors_backends.refbackend import RefBackendLinalgOnTensorsBackend
+from torch_mlir_e2e_test.linalg_on_tensors_backends.cpuprotobackend import CpuProtoLinalgOnTensorsBackend
 from torch_mlir_e2e_test.tosa_backends.linalg_on_tensors import LinalgOnTensorsTosaBackend
 
 from .xfail_sets import (
@@ -43,7 +44,7 @@ from torch_mlir_e2e_test.test_suite import register_all_tests
 register_all_tests()
 
 def _get_argparse():
-    config_choices = ["native_torch", "torchscript", "linalg", "make_fx_tosa", "tosa", "lazy_tensor_core", "torchdynamo"]
+    config_choices = ["native_torch", "torchscript", "linalg", "make_fx_tosa", "tosa", "lazy_tensor_core", "torchdynamo", "cpuproto"]
     parser = argparse.ArgumentParser(description="Run torchscript e2e tests.")
     parser.add_argument("-c", "--config",
         choices=config_choices,
@@ -92,11 +93,15 @@ Available options:
 "linalg-mlir-lowering": dump after-pass results in Linalg to LLVM pipeline
 "obj": dump compiled code to object file
 """)
+    parser.add_argument("--use-kernels",
+                        default=False,
+                        action="store_true",
+                        help="Enable linalg ops replacement with runtime library kernel calls.")
     return parser
 
 def main():
     args = _get_argparse().parse_args()
-    opts = TestOptions(dumps=args.dump)
+    opts = TestOptions(dumps=args.dump, use_kernels=args.use_kernels)
 
     all_test_unique_names = set(
         test.unique_name for test in GLOBAL_TEST_REGISTRY)
@@ -128,6 +133,10 @@ def main():
         crashing_set = LTC_CRASHING_SET
     elif args.config == "torchdynamo":
         config = TorchDynamoTestConfig(RefBackendLinalgOnTensorsBackend(), opts=opts)
+        xfail_set = TORCHDYNAMO_XFAIL_SET
+        crashing_set = TORCHDYNAMO_CRASHING_SET
+    elif args.config == "cpuproto":
+        config = TorchDynamoTestConfig(CpuProtoLinalgOnTensorsBackend(opts), opts=opts)
         xfail_set = TORCHDYNAMO_XFAIL_SET
         crashing_set = TORCHDYNAMO_CRASHING_SET
 

--- a/projects/pt1/python/torch_mlir_e2e_test/framework.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/framework.py
@@ -100,8 +100,9 @@ class TestOptions:
 
     dump_choices = ["all", "fx-graph", "torch-mlir", "linalg-mlir", "llvm-mlir", "torch-mlir-lowering", "linalg-mlir-lowering", "obj"]
 
-    def __init__(self, dumps: List[str] = []):
+    def __init__(self, *, dumps: List[str] = [], use_kernels=False):
         self.dumps = {opt for opt in dumps}
+        self.use_kernels = use_kernels
 
     def is_dump_enabled(self, dump: str):
         return dump in self.dumps or "all" in self.dumps

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
@@ -1,0 +1,131 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+import os
+
+from torch_mlir.ir import *
+from torch_mlir.passmanager import *
+from torch_mlir.execution_engine import *
+from torch_mlir.runtime import *
+from torch_mlir.compiler_utils import run_pipeline_with_repro_report
+from torch_mlir_e2e_test.framework import TestOptions
+
+from .abc import LinalgOnTensorsBackend
+from .refbackend import RefBackendInvoker
+
+__all__ = [
+    "CpuProtoLinalgOnTensorsBackend",
+]
+
+
+def _build_lowering_pipeline(opts: TestOptions):
+    passes = [
+        "func.func(refback-generalize-tensor-pad)",
+        # Apply some optimizations. It would be great if MLIR had more useful
+        # optimizations that worked out of the box here.
+        # Note: When measured, this doesn't seem to actually help that much
+        # for the linalg-on-tensors backend.
+        # This is likely because if things are naturally fusable we usually already
+        # emit things in that form from the high level (e.g. single linalg-generic).
+        # Other backends are likely to benefit more.
+        "func.func(linalg-fuse-elementwise-ops)",
+        "convert-shape-to-std",
+        # Bufferize.
+        "func.func(scf-bufferize)",
+        "func.func(tm-tensor-bufferize)",
+        "func.func(empty-tensor-to-alloc-tensor)",
+        "func.func(linalg-bufferize)",
+        "func-bufferize",
+        "arith-bufferize",
+        "refback-mlprogram-bufferize",
+        "func.func(tensor-bufferize)",
+        "func.func(finalizing-bufferize)",
+        "func.func(buffer-deallocation)",
+        # Munge to make it ExecutionEngine compatible.
+        # Specifically, we rewrite calling convention boundaries to be in terms
+        # of unranked memref, and we rewrite the return to actually be a
+        # callback that consumes the return (the final munged function always
+        # returns void at the C level -- we get the return value by providing the
+        # callback).
+        "refback-munge-calling-conventions"
+    ]
+    if opts.use_kernels:
+        # Introduce kernel calls for operations we want to execute using library
+        # kernels.
+        passes.append("convert-linalg-ops-to-kernel-calls")
+    passes.extend([
+        # Insert global variable and instruction sequence for getting the next
+        # global seed used in stateful rng.
+        # Lower to LLVM
+        "func.func(tm-tensor-to-loops)",
+        "func.func(refback-munge-memref-copy)",
+        "func.func(convert-linalg-to-loops)",
+        "func.func(lower-affine)",
+        "convert-scf-to-cf",
+        "func.func(refback-expand-ops-for-llvm)",
+        "func.func(arith-expand)",
+        "func.func(convert-math-to-llvm)",
+        # Handle some complex mlir::math ops (e.g. atan2)
+        "convert-math-to-libm",
+        "expand-strided-metadata",
+        "finalize-memref-to-llvm",
+        "lower-affine",
+        "convert-bufferization-to-memref",
+        "finalize-memref-to-llvm",
+        "func.func(convert-arith-to-llvm)",
+        "convert-func-to-llvm",
+        "convert-cf-to-llvm",
+        "convert-complex-to-llvm",
+        "reconcile-unrealized-casts"
+    ])
+    return "builtin.module(" + ",".join(passes) + ")"
+
+
+def _find_shared_lib(name):
+    this_file_dir = os.path.dirname(os.path.abspath(__file__))
+    lib_file_path = f"{this_file_dir}/../../torch_mlir/_mlir_libs/{name}"
+    if not os.path.isfile(lib_file_path):
+        raise RuntimeError(f"Cannot find runtime library: {lib_file_path}")
+    return lib_file_path
+
+
+def _collect_shared_libs(opts: TestOptions):
+    shared_libs = []
+    if opts.use_kernels:
+        shared_libs.append(_find_shared_lib("libTorchMLIRKernels.so"))
+    return shared_libs
+
+
+class CpuProtoLinalgOnTensorsBackend(LinalgOnTensorsBackend):
+    """Main entry-point for the reference backend."""
+    def __init__(self, opts: TestOptions = TestOptions()):
+        super().__init__()
+        self._opts = opts
+
+    def compile(self, imported_module: Module, ir_file: str = None):
+        """Compiles an imported module, with a flat list of functions.
+        The module is expected to be in linalg-on-tensors + scalar code form.
+        TODO: More clearly define the backend contract. Generally this will
+        extend to support globals, lists, and other stuff.
+
+        Args:
+          imported_module: The MLIR module consisting of funcs in the torch
+            dialect.
+          ir_file: If specified, use it as output file for MLIR passes dumps
+        Returns:
+          An opaque, backend specific compiled artifact object that can be
+          passed to `load`.
+        """
+
+        run_pipeline_with_repro_report(
+            imported_module, _build_lowering_pipeline(self._opts),
+            "Lowering Linalg-on-Tensors IR to LLVM with RefBackend", ir_file)
+        return imported_module
+
+    def load(self, module) -> RefBackendInvoker:
+        """Loads a compiled artifact into the runtime."""
+
+        return RefBackendInvoker(module,
+                                 shared_libs=_collect_shared_libs(self._opts))

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -80,8 +80,8 @@ def get_ctype_func(func_name):
 
 class RefBackendInvoker:
 
-    def __init__(self, module):
-        self.ee = ExecutionEngine(module)
+    def __init__(self, module, shared_libs=None):
+        self.ee = ExecutionEngine(module, shared_libs=shared_libs)
         self.result = None
 
         return_funcs = get_return_funcs(module)


### PR DESCRIPTION
This patch adds a few features:
* runtime library with a test matmul implementation, this can be later used as a wrapper for external libraries like DNN
* MLIR pass to replace `linalg.matmul` ops with runtime library function calls
* new linalg backend `CpuProtoLinalgOnTensorsBackend` that utilizes added pass and runtime 
* new config `cpuproto` for e2e tests that supports `--use-kernels` option to use added matmul kernels