### PR TITLE
[Transpose Matmul Fusion] PatternRewriter for linalg ops fusion

### DIFF
--- a/include/torch-mlir/Conversion/FuseLinalg/FuseLinalg.h
+++ b/include/torch-mlir/Conversion/FuseLinalg/FuseLinalg.h
@@ -1,0 +1,16 @@
+#ifndef TORCHMLIR_FUSE_LINALG_H
+#define TORCHMLIR_FUSE_LINALG_H
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace mlir {
+namespace torch {
+std::unique_ptr<mlir::OperationPass<ModuleOp>> createFuseLinalgOpsPass();
+}
+} // namespace mlir
+
+#endif // TORCHMLIR_FUSE_LINALG_H

--- a/include/torch-mlir/Conversion/Passes.td
+++ b/include/torch-mlir/Conversion/Passes.td
@@ -165,4 +165,15 @@ def ConvertLinalgOpsToKernelCalls
   }];
 }
 
+def FuseLinalgOps
+    : Pass<"fuse-linalg-ops", "ModuleOp"> {
+  let summary = "Fuse linalg operations.";
+  let constructor = [{
+    mlir::torch::createFuseLinalgOpsPass()
+  }];
+  let description = [{
+    This pass fuses linalg ops.
+  }];
+}
+
 #endif // TORCHMLIR_CONVERSION_PASSES

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(TorchToLinalg)
 add_subdirectory(TorchToSCF)
 add_subdirectory(TorchToArith)
 add_subdirectory(TorchToTosa)
+add_subdirectory(FuseLinalg)
 if(TORCH_MLIR_ENABLE_STABLEHLO)
   add_subdirectory(TorchToStablehlo)
 endif()
@@ -13,6 +14,7 @@ add_subdirectory(Utils)
 # TODO: Automate this with add_torch_mlir_conversion_library.
 set(linked_libs TorchMLIRLinalgToKernelCalls
                 TorchMLIRTorchToLinalg
+                FuseLinalg
                 TorchMLIRTorchToSCF
                 TorchMLIRTorchToArith
                 TorchMLIRTorchToTosa

--- a/lib/Conversion/FuseLinalg/CMakeLists.txt
+++ b/lib/Conversion/FuseLinalg/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_mlir_conversion_library(FuseLinalg
+  FuseLinalg.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/torch-mlir/Conversion/FuseLinalg
+
+  DEPENDS
+  TorchMLIRConversionPassIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRLinalgDialect
+)
+
+torch_mlir_target_includes(FuseLinalg)

--- a/lib/Conversion/FuseLinalg/FuseLinalg.cpp
+++ b/lib/Conversion/FuseLinalg/FuseLinalg.cpp
@@ -1,0 +1,128 @@
+#include "torch-mlir/Conversion/FuseLinalg/FuseLinalg.h"
+
+#include "../PassDetail.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MLProgram/IR/MLProgram.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include <algorithm>
+
+namespace {
+
+class MatmulTranspose : public mlir::OpRewritePattern<mlir::linalg::MatmulOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  mlir::LogicalResult
+  matchAndRewrite(mlir::linalg::MatmulOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+
+    auto mm_op = mlir::cast<mlir::linalg::MatmulOp>(&op);
+    auto inputs = mm_op->getInputs();
+    std::vector<int32_t> transposed_input_nums;
+    transposed_input_nums.reserve(inputs.size());
+
+    mlir::linalg::TransposeOp transposeOp = nullptr;
+    std::fill_n(std::back_inserter(transposed_input_nums), inputs.size(), -1);
+    if (transposed_input_nums.size() != 2) {
+      return rewriter.notifyMatchFailure(
+          op, "Inputs amount is not common for Matmul");
+    }
+
+    for (size_t num_input = 0; num_input < inputs.size(); num_input++) {
+      mlir::Value input = inputs[num_input];
+      transposeOp =
+          llvm::dyn_cast<mlir::linalg::TransposeOp>(input.getDefiningOp());
+      if (!transposeOp) {
+        continue;
+      }
+      transposed_input_nums[num_input] = num_input;
+    }
+
+    const int default_inps = std::count(transposed_input_nums.cbegin(),
+                                        transposed_input_nums.cend(), -1);
+    if (default_inps != 1) {
+      return rewriter.notifyMatchFailure(op, "Both Inputs is Transposed");
+    }
+
+    if (!transposeOp) {
+      return rewriter.notifyMatchFailure(op, "Input is not TransposeOp");
+    }
+    /* Maybe we need this
+    if (isListPotential[ERROR] lyMutated(transposeOp.getResult()))
+      return rewriter.notifyMatchFailure(
+          op, "TransposeOp result is potentially mutated");
+    */
+
+    mlir::Location loc = op.getLoc();
+
+    mlir::SmallVector<mlir::Value> fusedInputOperands, fusedOutputOperands;
+    mlir::SmallVector<mlir::Type> fusedResultTypes;
+    for (mlir::OpOperand &opOperand : op.getOutputsMutable()) {
+      fusedOutputOperands.push_back(opOperand.get());
+      mlir::Type resultType = opOperand.get().getType();
+      if (!mlir::isa<mlir::MemRefType>(resultType))
+        fusedResultTypes.push_back(resultType);
+    }
+
+    mlir::Value matmul;
+    if (transposed_input_nums[0] != -1) {
+      fusedInputOperands.push_back(transposeOp.getInputMutable().get());
+      fusedInputOperands.push_back(op.getInputsMutable()[1].get());
+
+      auto mm_a = rewriter.create<mlir::linalg::MatmulTransposeAOp>(
+          loc, fusedResultTypes, fusedInputOperands, fusedOutputOperands);
+      matmul = mm_a.getResult(0);
+    } else if (transposed_input_nums[1] != -1) {
+      fusedInputOperands.push_back(op.getInputsMutable()[0].get());
+      fusedInputOperands.push_back(transposeOp.getInputMutable().get());
+
+      auto mm_b = rewriter.create<mlir::linalg::MatmulTransposeBOp>(
+          loc, fusedResultTypes, fusedInputOperands, fusedOutputOperands);
+
+      matmul = mm_b.getResult(0);
+    }
+
+    rewriter.replaceUsesWithIf(
+        op.getResult(0), matmul, [&](mlir::OpOperand &use) {
+          // Only replace consumer uses.
+          return use.get().getDefiningOp() != transposeOp;
+        });
+    rewriter.eraseOp(op);
+
+    if (transposeOp.getResult().use_empty()) {
+      rewriter.eraseOp(transposeOp);
+    } 
+    return mlir::success();
+  }
+};
+
+class FuseLinalgOps : public mlir::torch::FuseLinalgOpsBase<FuseLinalgOps> {
+public:
+  void runOnOperation() override {
+    mlir::MLIRContext *context = &getContext();
+    mlir::RewritePatternSet patterns(context);
+
+    // pattern.add calls go here
+    patterns.add<MatmulTranspose>(context);
+
+    mlir::GreedyRewriteConfig config;
+    config.useTopDownTraversal = true;
+
+    if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns),
+                                            config))) {
+      mlir::emitError(getOperation()->getLoc(), "failure in Linalg fusion");
+      signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
+mlir::torch::createFuseLinalgOpsPass() {
+  return std::make_unique<FuseLinalgOps>();
+}

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -20,6 +20,7 @@
 #include "torch-mlir/Conversion/TorchToTosa/TorchToTosa.h"
 #include "torch-mlir/Conversion/TorchToTMTensor/TorchToTMTensor.h"
 #include "torch-mlir/Conversion/TorchConversionToMLProgram/TorchConversionToMLProgram.h"
+#include "torch-mlir/Conversion/FuseLinalg/FuseLinalg.h"
 
 //===----------------------------------------------------------------------===//
 // Pass registration

--- a/lib/Runtime/Kernels.cpp
+++ b/lib/Runtime/Kernels.cpp
@@ -72,6 +72,41 @@ extern "C" void matmul_kernel_f32(int64_t lhs_rank, tensor<float> *lhs,
               lhs->data, k, rhs->data, n, beta, res->data, n);
 }
 
+extern "C" void
+matmul_transpose_b_kernel_f32(int64_t lhs_rank, tensor<float> *lhs,
+                              int64_t rhs_rank, tensor<float> *rhs,
+                              int64_t res_rank, tensor<float> *res) {
+  // trace_matmul_call(lhs_rank, lhs, rhs_rank, rhs, res_rank, res);
+  float alpha = 1.0;
+  float beta = 1.0;
+  auto m = lhs->rank[0];
+  auto k = lhs->rank[1];
+  auto n = rhs->rank[0];
+  // std::cout << "Using MKL implementation. [m(rows op(A)): " << m
+  //           << ", k(cols op(A)): " << k << ", n(cols op(B)  = cols C): " << n
+  //           << "]" << std::endl;
+  cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, m, n, k, alpha,
+              lhs->data, k, rhs->data, k, beta, res->data, n);
+}
+
+extern "C" void
+matmul_transpose_a_kernel_f32(int64_t lhs_rank, tensor<float> *lhs,
+                              int64_t rhs_rank, tensor<float> *rhs,
+                              int64_t res_rank, tensor<float> *res) {
+  // trace_matmul_call(lhs_rank, lhs, rhs_rank, rhs, res_rank, res);
+  std::cout << "[Matmul transpose a] Not tested MKL implementation." << std::endl;
+  float alpha = 1.0;
+  float beta = 1.0;
+  auto m = lhs->rank[1];
+  auto k = lhs->rank[0];
+  auto n = rhs->rank[1];
+  // std::cout << "Using MKL implementation. [m(rows op(A)): " << m
+  //           << ", k(cols op(A)): " << k << ", n(cols op(B)  = cols C): " << n
+  //           << "]" << std::endl;
+  cblas_sgemm(CblasRowMajor, CblasTrans, CblasNoTrans, m, n, k, alpha,
+              lhs->data, k, rhs->data, k, beta, res->data, n);
+}
+
 extern "C" void matmul_kernel_f64(int64_t lhs_rank, tensor<double> *lhs,
                                   int64_t rhs_rank, tensor<double> *rhs,
                                   int64_t res_rank, tensor<double> *res) {

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
@@ -22,6 +22,7 @@ __all__ = [
 
 def _build_lowering_pipeline(opts: TestOptions):
     passes = [
+        "fuse-linalg-ops",
         "func.func(refback-generalize-tensor-pad)",
         # Apply some optimizations. It would be great if MLIR had more useful
         # optimizations that worked out of the box here.

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/mlp.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/mlp.py
@@ -99,3 +99,44 @@ class BatchMlpLayerModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: BatchMlpLayerModule())
 def BatchMlpLayerModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(7, 5, 3))
+
+
+class MLP(torch.nn.Module):
+    def __init__(self, input_dim, output_dim):
+        super().__init__()
+        self.flatten = torch.nn.Flatten()
+        self.linear1 = torch.nn.Linear(input_dim, input_dim // 2)
+        # self.relu = torch.nn.ReLU()
+        # self.linear2 = torch.nn.Linear(input_dim // 2, output_dim)
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        x = self.flatten(x)
+        x = self.linear1(x)
+        # x = self.relu(x)
+        # x = self.linear2(x)
+        return x
+
+model = MLP(128 * 128, 0)
+
+def model_factory():
+    return model
+
+
+test_input = torch.rand(1, 128, 128)
+w = model.linear1.weight.detach().numpy()
+b = model.linear1.bias.detach().numpy()
+print("in shape: ", test_input.shape)
+print(" w shape: ", w.shape)
+print(" b shape: ", b.shape)
+
+
+@register_test_case(module_factory=model_factory)
+def MLP_basic(module, tu: TestUtils):
+    out = module.forward(test_input)
+    print("[test body] out shape: ", out.size())
+


### PR DESCRIPTION
This commit introduces FuseLinalgOpsPass that merges Transpose in any
matmul argument for Linalg dialect. The conversion from torch to
linalg has also been changed and `aten::mm` is converted to `linalg::matmul`
instead of `linalg::generic`.

Signed-off-by: Dmitrii Makarenko <dmitrii.makarenko@intel.com>
