### PR TITLE
Use static MKL libs for runtime.

### DIFF
--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -1,10 +1,11 @@
+set(MKL_LINK "static")
 find_package(MKL CONFIG REQUIRED)
 
 add_library(TorchMLIRKernels SHARED Kernels.cpp)
 
 target_compile_options(TorchMLIRKernels PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>)
 target_include_directories(TorchMLIRKernels PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>)
-target_link_libraries(TorchMLIRKernels PUBLIC $<LINK_ONLY:MKL::MKL>)
+target_link_libraries(TorchMLIRKernels PRIVATE $<LINK_ONLY:MKL::MKL>)
 
 set_target_properties(TorchMLIRKernels PROPERTIES
          LIBRARY_OUTPUT_DIRECTORY "${TORCH_MLIR_PYTHON_PACKAGES_DIR}/torch_mlir/torch_mlir/_mlir_libs")


### PR DESCRIPTION
This helps to avoid conflicts with other BLAS libs that might be used by python libraries.