### PR TITLE
[Bufferization] Enable OneShot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,13 +163,6 @@ if(MLIR_ENABLE_BINDINGS_PYTHON)
   mlir_configure_python_dev_packages()
 endif()
 
-add_subdirectory(include)
-add_subdirectory(lib)
-add_subdirectory(tools)
-
-add_custom_target(check-torch-mlir-all)
-add_dependencies(check-torch-mlir-all check-torch-mlir)
-
 if(MLIR_ENABLE_BINDINGS_PYTHON)
   # If parent projects want to configure where to place the python packages,
   # respect that.
@@ -177,6 +170,13 @@ if(MLIR_ENABLE_BINDINGS_PYTHON)
     set(TORCH_MLIR_PYTHON_PACKAGES_DIR "${CMAKE_CURRENT_BINARY_DIR}/python_packages")
   endif()
 endif()
+
+add_subdirectory(include)
+add_subdirectory(lib)
+add_subdirectory(tools)
+
+add_custom_target(check-torch-mlir-all)
+add_dependencies(check-torch-mlir-all check-torch-mlir)
 
 add_subdirectory(test)
 

--- a/conda-dev-env.yml
+++ b/conda-dev-env.yml
@@ -1,0 +1,21 @@
+#  To create environment, execute:
+#     conda env create -f conda-dev-env.yml
+#
+#  To activate:
+#     conda activate mlir-dev
+#
+name: mlir-dev
+channels:
+  - conda-forge
+
+dependencies:
+  - gxx_linux-64   12.*
+  - gcc_linux-64   12.*
+  - ccache
+  - sysroot_linux-64 >=2.14
+  - llvmdev     16.*
+  - cmake
+  - make
+  - llvm
+  - python      ==3.11
+  - mkl

--- a/include/torch-mlir/Conversion/FuseLinalg/FuseLinalg.h
+++ b/include/torch-mlir/Conversion/FuseLinalg/FuseLinalg.h
@@ -1,0 +1,16 @@
+#ifndef TORCHMLIR_FUSE_LINALG_H
+#define TORCHMLIR_FUSE_LINALG_H
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace mlir {
+namespace torch {
+std::unique_ptr<mlir::OperationPass<ModuleOp>> createFuseLinalgOpsPass();
+}
+} // namespace mlir
+
+#endif // TORCHMLIR_FUSE_LINALG_H

--- a/include/torch-mlir/Conversion/LinalgToKernelCalls/LinalgToKernelCalls.h
+++ b/include/torch-mlir/Conversion/LinalgToKernelCalls/LinalgToKernelCalls.h
@@ -1,0 +1,25 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TORCHMLIR_CONVERSION_LINALGTOKERNELCALLS_LINALGTOKERNELCALLS_H
+#define TORCHMLIR_CONVERSION_LINALGTOKERNELCALLS_LINALGTOKERNELCALLS_H
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace mlir {
+namespace torch {
+std::unique_ptr<OperationPass<ModuleOp>>
+createConvertLinalgOpsToKernelCallsPass();
+}
+} // namespace mlir
+
+#endif // TORCHMLIR_CONVERSION_LINALGTOKERNELCALLS_LINALGTOKERNELCALLS_H

--- a/include/torch-mlir/Conversion/Passes.td
+++ b/include/torch-mlir/Conversion/Passes.td
@@ -154,4 +154,15 @@ def ConvertTorchToStablehlo : Pass<"convert-torch-to-stablehlo", "func::FuncOp">
 }
 #endif
 
+def ConvertLinalgOpsToKernelCalls
+    : Pass<"convert-linalg-ops-to-kernel-calls", "ModuleOp"> {
+  let summary = "Lower linalg.matmul operation to kernel call.";
+  let constructor = [{
+    mlir::torch::createConvertLinalgOpsToKernelCallsPass()
+  }];
+  let description = [{
+    This pass replaces linalg.matmul operations with calls to the runtime library.
+  }];
+}
+
 #endif // TORCHMLIR_CONVERSION_PASSES

--- a/include/torch-mlir/Conversion/Passes.td
+++ b/include/torch-mlir/Conversion/Passes.td
@@ -165,4 +165,15 @@ def ConvertLinalgOpsToKernelCalls
   }];
 }
 
+def FuseLinalgOps
+    : Pass<"fuse-linalg-ops", "ModuleOp"> {
+  let summary = "Fuse linalg operations.";
+  let constructor = [{
+    mlir::torch::createFuseLinalgOpsPass()
+  }];
+  let description = [{
+    This pass fuses linalg ops.
+  }];
+}
+
 #endif // TORCHMLIR_CONVERSION_PASSES

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(CAPI)
 add_subdirectory(Conversion)
 add_subdirectory(Dialect)
+add_subdirectory(Runtime)
 
 set(LinkedLibs
   MLIRComplexDialect

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(LinalgToKernelCalls)
 add_subdirectory(TorchToLinalg)
 add_subdirectory(TorchToSCF)
 add_subdirectory(TorchToArith)
@@ -10,7 +11,8 @@ add_subdirectory(TorchConversionToMLProgram)
 add_subdirectory(Utils)
 
 # TODO: Automate this with add_torch_mlir_conversion_library.
-set(linked_libs TorchMLIRTorchToLinalg
+set(linked_libs TorchMLIRLinalgToKernelCalls
+                TorchMLIRTorchToLinalg
                 TorchMLIRTorchToSCF
                 TorchMLIRTorchToArith
                 TorchMLIRTorchToTosa

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(TorchToLinalg)
 add_subdirectory(TorchToSCF)
 add_subdirectory(TorchToArith)
 add_subdirectory(TorchToTosa)
+add_subdirectory(FuseLinalg)
 if(TORCH_MLIR_ENABLE_STABLEHLO)
   add_subdirectory(TorchToStablehlo)
 endif()
@@ -13,6 +14,7 @@ add_subdirectory(Utils)
 # TODO: Automate this with add_torch_mlir_conversion_library.
 set(linked_libs TorchMLIRLinalgToKernelCalls
                 TorchMLIRTorchToLinalg
+                FuseLinalg
                 TorchMLIRTorchToSCF
                 TorchMLIRTorchToArith
                 TorchMLIRTorchToTosa

--- a/lib/Conversion/FuseLinalg/CMakeLists.txt
+++ b/lib/Conversion/FuseLinalg/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_mlir_conversion_library(FuseLinalg
+  FuseLinalg.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/torch-mlir/Conversion/FuseLinalg
+
+  DEPENDS
+  TorchMLIRConversionPassIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRLinalgDialect
+)
+
+torch_mlir_target_includes(FuseLinalg)

--- a/lib/Conversion/FuseLinalg/FuseLinalg.cpp
+++ b/lib/Conversion/FuseLinalg/FuseLinalg.cpp
@@ -1,0 +1,128 @@
+#include "torch-mlir/Conversion/FuseLinalg/FuseLinalg.h"
+
+#include "../PassDetail.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MLProgram/IR/MLProgram.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include <algorithm>
+
+namespace {
+
+class MatmulTranspose : public mlir::OpRewritePattern<mlir::linalg::MatmulOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  mlir::LogicalResult
+  matchAndRewrite(mlir::linalg::MatmulOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+
+    auto mm_op = mlir::cast<mlir::linalg::MatmulOp>(&op);
+    auto inputs = mm_op->getInputs();
+    std::vector<int32_t> transposed_input_nums;
+    transposed_input_nums.reserve(inputs.size());
+
+    mlir::linalg::TransposeOp transposeOp = nullptr;
+    std::fill_n(std::back_inserter(transposed_input_nums), inputs.size(), -1);
+    if (transposed_input_nums.size() != 2) {
+      return rewriter.notifyMatchFailure(
+          op, "Inputs amount is not common for Matmul");
+    }
+
+    for (size_t num_input = 0; num_input < inputs.size(); num_input++) {
+      mlir::Value input = inputs[num_input];
+      transposeOp =
+          llvm::dyn_cast<mlir::linalg::TransposeOp>(input.getDefiningOp());
+      if (!transposeOp) {
+        continue;
+      }
+      transposed_input_nums[num_input] = num_input;
+    }
+
+    const int default_inps = std::count(transposed_input_nums.cbegin(),
+                                        transposed_input_nums.cend(), -1);
+    if (default_inps != 1) {
+      return rewriter.notifyMatchFailure(op, "Both Inputs is Transposed");
+    }
+
+    if (!transposeOp) {
+      return rewriter.notifyMatchFailure(op, "Input is not TransposeOp");
+    }
+    /* Maybe we need this
+    if (isListPotential[ERROR] lyMutated(transposeOp.getResult()))
+      return rewriter.notifyMatchFailure(
+          op, "TransposeOp result is potentially mutated");
+    */
+
+    mlir::Location loc = op.getLoc();
+
+    mlir::SmallVector<mlir::Value> fusedInputOperands, fusedOutputOperands;
+    mlir::SmallVector<mlir::Type> fusedResultTypes;
+    for (mlir::OpOperand &opOperand : op.getOutputsMutable()) {
+      fusedOutputOperands.push_back(opOperand.get());
+      mlir::Type resultType = opOperand.get().getType();
+      if (!mlir::isa<mlir::MemRefType>(resultType))
+        fusedResultTypes.push_back(resultType);
+    }
+
+    mlir::Value matmul;
+    if (transposed_input_nums[0] != -1) {
+      fusedInputOperands.push_back(transposeOp.getInputMutable().get());
+      fusedInputOperands.push_back(op.getInputsMutable()[1].get());
+
+      auto mm_a = rewriter.create<mlir::linalg::MatmulTransposeAOp>(
+          loc, fusedResultTypes, fusedInputOperands, fusedOutputOperands);
+      matmul = mm_a.getResult(0);
+    } else if (transposed_input_nums[1] != -1) {
+      fusedInputOperands.push_back(op.getInputsMutable()[0].get());
+      fusedInputOperands.push_back(transposeOp.getInputMutable().get());
+
+      auto mm_b = rewriter.create<mlir::linalg::MatmulTransposeBOp>(
+          loc, fusedResultTypes, fusedInputOperands, fusedOutputOperands);
+
+      matmul = mm_b.getResult(0);
+    }
+
+    rewriter.replaceUsesWithIf(
+        op.getResult(0), matmul, [&](mlir::OpOperand &use) {
+          // Only replace consumer uses.
+          return use.get().getDefiningOp() != transposeOp;
+        });
+    rewriter.eraseOp(op);
+
+    if (transposeOp.getResult().use_empty()) {
+      rewriter.eraseOp(transposeOp);
+    } 
+    return mlir::success();
+  }
+};
+
+class FuseLinalgOps : public mlir::torch::FuseLinalgOpsBase<FuseLinalgOps> {
+public:
+  void runOnOperation() override {
+    mlir::MLIRContext *context = &getContext();
+    mlir::RewritePatternSet patterns(context);
+
+    // pattern.add calls go here
+    patterns.add<MatmulTranspose>(context);
+
+    mlir::GreedyRewriteConfig config;
+    config.useTopDownTraversal = true;
+
+    if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns),
+                                            config))) {
+      mlir::emitError(getOperation()->getLoc(), "failure in Linalg fusion");
+      signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
+mlir::torch::createFuseLinalgOpsPass() {
+  return std::make_unique<FuseLinalgOps>();
+}

--- a/lib/Conversion/LinalgToKernelCalls/CMakeLists.txt
+++ b/lib/Conversion/LinalgToKernelCalls/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_mlir_conversion_library(TorchMLIRLinalgToKernelCalls
+  LinalgToKernelCalls.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/torch-mlir/Conversion/TorchToLinalg
+
+  DEPENDS
+  TorchMLIRConversionPassIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRLinalgDialect
+  MLIRMathDialect
+  TorchMLIRTorchDialect
+)
+
+torch_mlir_target_includes(TorchMLIRLinalgToKernelCalls)

--- a/lib/Conversion/LinalgToKernelCalls/LinalgToKernelCalls.cpp
+++ b/lib/Conversion/LinalgToKernelCalls/LinalgToKernelCalls.cpp
@@ -1,0 +1,126 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Conversion/LinalgToKernelCalls/LinalgToKernelCalls.h"
+
+#include "../PassDetail.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Complex/IR/Complex.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionDialect.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
+#include "torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
+
+#include <iostream>
+
+using namespace mlir;
+using namespace mlir::torch;
+using namespace mlir::torch::Torch;
+
+namespace {
+LogicalResult
+convertLinalgOpsInFunc(func::FuncOp func,
+                       std::map<std::string, SmallVector<Type>> &usedKernels) {
+  OpBuilder b(func.getBody());
+  SmallVector<Operation *> replacedOps;
+  func.walk([&](linalg::MatmulOp op) {
+    auto types = op.getOperandTypes();
+    auto lhs_type = types[0];
+    auto rhs_type = types[1];
+    auto res_type = types[2];
+    auto lhs_elem_type = lhs_type.cast<BaseMemRefType>().getElementType();
+    auto rhs_elem_type = rhs_type.cast<BaseMemRefType>().getElementType();
+    auto res_elem_type = res_type.cast<BaseMemRefType>().getElementType();
+
+    if (lhs_elem_type != rhs_elem_type || lhs_elem_type != res_elem_type)
+      return;
+
+    if (lhs_type.cast<BaseMemRefType>().getMemorySpace() !=
+            rhs_type.cast<BaseMemRefType>().getMemorySpace() ||
+        lhs_type.cast<BaseMemRefType>().getMemorySpace() !=
+            res_type.cast<BaseMemRefType>().getMemorySpace())
+      return;
+
+    if (!lhs_elem_type.isF16() && !lhs_elem_type.isF32() &&
+        !lhs_elem_type.isF64())
+      return;
+
+    b.setInsertionPoint(op);
+
+    auto unranked_type = UnrankedMemRefType::get(
+        lhs_elem_type, lhs_type.cast<BaseMemRefType>().getMemorySpace());
+    std::string fn_name = "matmul_kernel_";
+    llvm::raw_string_ostream rss(fn_name);
+    lhs_elem_type.print(rss);
+    if (!usedKernels.count(fn_name)) {
+      usedKernels.emplace(
+          fn_name,
+          SmallVector<Type>({unranked_type, unranked_type, unranked_type}));
+    }
+
+    SmallVector<Value> unranked_ops;
+    for (auto op : op.getOperands())
+      unranked_ops.push_back(
+          b.create<memref::CastOp>(op.getLoc(), unranked_type, op));
+    b.create<func::CallOp>(op.getLoc(), fn_name, TypeRange({}), unranked_ops);
+    replacedOps.push_back(op);
+  });
+
+  for (Operation *op : replacedOps)
+    op->erase();
+
+  return success();
+}
+} // namespace
+
+namespace {
+class ConvertLinalgOpsToKernelCalls
+    : public ConvertLinalgOpsToKernelCallsBase<ConvertLinalgOpsToKernelCalls> {
+public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect>();
+    registry.insert<math::MathDialect>();
+    registry.insert<func::FuncDialect>();
+    registry.insert<tensor::TensorDialect>();
+    registry.insert<arith::ArithDialect>();
+    registry.insert<cf::ControlFlowDialect>();
+    registry.insert<complex::ComplexDialect>();
+  }
+
+  void runOnOperation() override {
+    auto module = getOperation();
+    OpBuilder b(module.getBodyRegion());
+    std::map<std::string, SmallVector<Type>> usedKernels;
+    for (auto func : module.getOps<func::FuncOp>()) {
+      if (failed(convertLinalgOpsInFunc(func, usedKernels)))
+        return signalPassFailure();
+    }
+
+    // Create FuncOp for each used kernel function.
+    for (auto &p : usedKernels) {
+      auto kernelFunc = b.create<func::FuncOp>(
+          module.getLoc(), p.first,
+          FunctionType::get(module.getContext(), p.second, {}));
+      kernelFunc.setPrivate();
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::torch::createConvertLinalgOpsToKernelCallsPass() {
+  return std::make_unique<ConvertLinalgOpsToKernelCalls>();
+}

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -20,6 +20,7 @@
 #include "torch-mlir/Conversion/TorchToTosa/TorchToTosa.h"
 #include "torch-mlir/Conversion/TorchToTMTensor/TorchToTMTensor.h"
 #include "torch-mlir/Conversion/TorchConversionToMLProgram/TorchConversionToMLProgram.h"
+#include "torch-mlir/Conversion/FuseLinalg/FuseLinalg.h"
 
 //===----------------------------------------------------------------------===//
 // Pass registration

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -13,6 +13,7 @@
 #include "torch-mlir/Conversion/TorchToStablehlo/TorchToStablehlo.h"
 #endif // TORCH_MLIR_ENABLE_STABLEHLO
 
+#include "torch-mlir/Conversion/LinalgToKernelCalls/LinalgToKernelCalls.h"
 #include "torch-mlir/Conversion/TorchToLinalg/TorchToLinalg.h"
 #include "torch-mlir/Conversion/TorchToSCF/TorchToSCF.h"
 #include "torch-mlir/Conversion/TorchToArith/TorchToArith.h"

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -1,10 +1,11 @@
+set(MKL_LINK "static")
 find_package(MKL CONFIG REQUIRED)
 
 add_library(TorchMLIRKernels SHARED Kernels.cpp)
 
 target_compile_options(TorchMLIRKernels PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>)
 target_include_directories(TorchMLIRKernels PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>)
-target_link_libraries(TorchMLIRKernels PUBLIC $<LINK_ONLY:MKL::MKL>)
+target_link_libraries(TorchMLIRKernels PRIVATE $<LINK_ONLY:MKL::MKL>)
 
 set_target_properties(TorchMLIRKernels PROPERTIES
          LIBRARY_OUTPUT_DIRECTORY "${TORCH_MLIR_PYTHON_PACKAGES_DIR}/torch_mlir/torch_mlir/_mlir_libs")

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -1,0 +1,10 @@
+find_package(MKL CONFIG REQUIRED)
+
+add_library(TorchMLIRKernels SHARED Kernels.cpp)
+
+target_compile_options(TorchMLIRKernels PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>)
+target_include_directories(TorchMLIRKernels PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>)
+target_link_libraries(TorchMLIRKernels PUBLIC $<LINK_ONLY:MKL::MKL>)
+
+set_target_properties(TorchMLIRKernels PROPERTIES
+         LIBRARY_OUTPUT_DIRECTORY "${TORCH_MLIR_PYTHON_PACKAGES_DIR}/torch_mlir/torch_mlir/_mlir_libs")

--- a/lib/Runtime/Kernels.cpp
+++ b/lib/Runtime/Kernels.cpp
@@ -72,6 +72,41 @@ extern "C" void matmul_kernel_f32(int64_t lhs_rank, tensor<float> *lhs,
               lhs->data, k, rhs->data, n, beta, res->data, n);
 }
 
+extern "C" void
+matmul_transpose_b_kernel_f32(int64_t lhs_rank, tensor<float> *lhs,
+                              int64_t rhs_rank, tensor<float> *rhs,
+                              int64_t res_rank, tensor<float> *res) {
+  // trace_matmul_call(lhs_rank, lhs, rhs_rank, rhs, res_rank, res);
+  float alpha = 1.0;
+  float beta = 1.0;
+  auto m = lhs->rank[0];
+  auto k = lhs->rank[1];
+  auto n = rhs->rank[0];
+  // std::cout << "Using MKL implementation. [m(rows op(A)): " << m
+  //           << ", k(cols op(A)): " << k << ", n(cols op(B)  = cols C): " << n
+  //           << "]" << std::endl;
+  cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, m, n, k, alpha,
+              lhs->data, k, rhs->data, k, beta, res->data, n);
+}
+
+extern "C" void
+matmul_transpose_a_kernel_f32(int64_t lhs_rank, tensor<float> *lhs,
+                              int64_t rhs_rank, tensor<float> *rhs,
+                              int64_t res_rank, tensor<float> *res) {
+  // trace_matmul_call(lhs_rank, lhs, rhs_rank, rhs, res_rank, res);
+  std::cout << "[Matmul transpose a] Not tested MKL implementation." << std::endl;
+  float alpha = 1.0;
+  float beta = 1.0;
+  auto m = lhs->rank[1];
+  auto k = lhs->rank[0];
+  auto n = rhs->rank[1];
+  // std::cout << "Using MKL implementation. [m(rows op(A)): " << m
+  //           << ", k(cols op(A)): " << k << ", n(cols op(B)  = cols C): " << n
+  //           << "]" << std::endl;
+  cblas_sgemm(CblasRowMajor, CblasTrans, CblasNoTrans, m, n, k, alpha,
+              lhs->data, k, rhs->data, k, beta, res->data, n);
+}
+
 extern "C" void matmul_kernel_f64(int64_t lhs_rank, tensor<double> *lhs,
                                   int64_t rhs_rank, tensor<double> *rhs,
                                   int64_t res_rank, tensor<double> *res) {

--- a/lib/Runtime/Kernels.cpp
+++ b/lib/Runtime/Kernels.cpp
@@ -1,0 +1,85 @@
+#include <cstdint>
+#include <iostream>
+
+#include "mkl.h"
+
+template <typename T> struct tensor {
+  T *buffer;         // Allocated memory, used for deallocation only
+  T *data;           // Aligned data.
+  int64_t offset;    // Offset (in elems) to the first element
+  int64_t rank[2];   // Shape in elems
+  int64_t stride[2]; // Strides in elems
+
+  T &ref(int64_t i, int64_t j) {
+    return *(data + i * stride[0] + j * stride[1]);
+  }
+};
+
+namespace {
+template <typename T>
+void trace_matmul_call(int64_t lhs_rank, tensor<T> *lhs, int64_t rhs_rank,
+                       tensor<T> *rhs, int64_t res_rank, tensor<T> *res) {
+  std::cout << "test_matmul" << std::endl;
+  std::cout << "  lhs_rank=" << lhs_rank << std::endl
+            << "  rhs_rank=" << rhs_rank << std::endl
+            << "  res_rank=" << res_rank << std::endl;
+  std::cout << "  lhs={" << lhs->buffer << ", " << lhs->data << ", "
+            << lhs->offset << ", [" << lhs->rank[0] << ", " << lhs->rank[1]
+            << "], [" << lhs->stride[0] << ", " << lhs->stride[1] << "]}"
+            << std::endl;
+  std::cout << "  rhs={" << rhs->buffer << ", " << rhs->data << ", "
+            << rhs->offset << ", [" << rhs->rank[0] << ", " << rhs->rank[1]
+            << "], [" << rhs->stride[0] << ", " << rhs->stride[1] << "]}"
+            << std::endl;
+  std::cout << "  res={" << res->buffer << ", " << res->data << ", "
+            << res->offset << ", [" << res->rank[0] << ", " << res->rank[1]
+            << "], [" << res->stride[0] << ", " << res->stride[1] << "]}"
+            << std::endl;
+}
+
+template <typename T>
+void test_matmul(int64_t lhs_rank, tensor<T> *lhs, int64_t rhs_rank,
+                 tensor<T> *rhs, int64_t res_rank, tensor<T> *res) {
+  trace_matmul_call(lhs_rank, lhs, rhs_rank, rhs, res_rank, res);
+  std::cout << "Using naive implementation." << std::endl;
+  for (int64_t i = 0; i < lhs->rank[0]; ++i) {
+    for (int64_t j = 0; j < rhs->rank[1]; ++j) {
+      for (int64_t k = 0; k < rhs->rank[0]; ++k) {
+        res->ref(i, j) += lhs->ref(i, k) * rhs->ref(k, j);
+      }
+    }
+  }
+}
+} // namespace
+
+// extern "C" void test_matmul_f16(int64_t lhs_rank, tensor<_Float16> *lhs,
+//                                 int64_t rhs_rank, tensor<_Float16> *rhs,
+//                                 int64_t res_rank, tensor<_Float16> *res) {
+//   test_matmul(lhs_rank, lhs, rhs_rank, rhs, res_rank, res);
+// }
+
+extern "C" void matmul_kernel_f32(int64_t lhs_rank, tensor<float> *lhs,
+                                  int64_t rhs_rank, tensor<float> *rhs,
+                                  int64_t res_rank, tensor<float> *res) {
+  // trace_matmul_call(lhs_rank, lhs, rhs_rank, rhs, res_rank, res);
+  // std::cout << "Using MKL implementation." << std::endl;
+  float alpha = 1.0;
+  float beta = 1.0;
+  auto m = lhs->rank[0];
+  auto k = lhs->rank[1];
+  auto n = rhs->rank[1];
+  cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, m, n, k, alpha,
+              lhs->data, k, rhs->data, n, beta, res->data, n);
+}
+
+extern "C" void matmul_kernel_f64(int64_t lhs_rank, tensor<double> *lhs,
+                                  int64_t rhs_rank, tensor<double> *rhs,
+                                  int64_t res_rank, tensor<double> *res) {
+  double alpha = 1.0;
+  double beta = 1.0;
+  auto m = lhs->rank[0];
+  auto k = lhs->rank[1];
+  auto n = rhs->rank[1];
+  cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, m, n, k, alpha,
+              lhs->data, k, rhs->data, n, beta, res->data, n);
+}

--- a/projects/pt1/e2e_testing/main.py
+++ b/projects/pt1/e2e_testing/main.py
@@ -61,6 +61,10 @@ Meaning of options:
     parser.add_argument("-f", "--filter", default=".*", help="""
 Regular expression specifying which tests to include in this run.
 """)
+    parser.add_argument("-l", "--list_tests",
+                        default=False,
+                        action="store_true",
+                        help="List all available tests and exit.")
     parser.add_argument("-v", "--verbose",
                         default=False,
                         action="store_true",
@@ -97,11 +101,15 @@ Available options:
                         default=False,
                         action="store_true",
                         help="Enable linalg ops replacement with runtime library kernel calls.")
+    parser.add_argument("--enable-timer",
+                        default=False,
+                        action="store_true",
+                        help="Enable debug timings collection.")
     return parser
 
 def main():
     args = _get_argparse().parse_args()
-    opts = TestOptions(dumps=args.dump, use_kernels=args.use_kernels)
+    opts = TestOptions(dumps=args.dump, use_kernels=args.use_kernels, debug_timer=args.enable_timer)
 
     all_test_unique_names = set(
         test.unique_name for test in GLOBAL_TEST_REGISTRY)
@@ -142,6 +150,12 @@ def main():
 
     do_not_attempt = set(args.crashing_tests_to_not_attempt_to_run_and_a_bug_is_filed or []).union(crashing_set)
     available_tests = [test for test in GLOBAL_TEST_REGISTRY if test.unique_name not in do_not_attempt]
+
+    if args.list_tests is True:
+        for test in available_tests:
+            print(test.unique_name)
+        sys.exit(0)
+
     if args.crashing_tests_to_not_attempt_to_run_and_a_bug_is_filed is not None:
         for arg in args.crashing_tests_to_not_attempt_to_run_and_a_bug_is_filed:
             if arg not in all_test_unique_names:

--- a/projects/pt1/e2e_testing/main.py
+++ b/projects/pt1/e2e_testing/main.py
@@ -24,6 +24,7 @@ from torch_mlir_e2e_test.configs import (
 )
 
 from torch_mlir_e2e_test.linalg_on_tensors_backends.refbackend import RefBackendLinalgOnTensorsBackend
+from torch_mlir_e2e_test.linalg_on_tensors_backends.cpuprotobackend import CpuProtoLinalgOnTensorsBackend
 from torch_mlir_e2e_test.tosa_backends.linalg_on_tensors import LinalgOnTensorsTosaBackend
 
 from .xfail_sets import (
@@ -43,7 +44,7 @@ from torch_mlir_e2e_test.test_suite import register_all_tests
 register_all_tests()
 
 def _get_argparse():
-    config_choices = ["native_torch", "torchscript", "linalg", "make_fx_tosa", "tosa", "lazy_tensor_core", "torchdynamo"]
+    config_choices = ["native_torch", "torchscript", "linalg", "make_fx_tosa", "tosa", "lazy_tensor_core", "torchdynamo", "cpuproto"]
     parser = argparse.ArgumentParser(description="Run torchscript e2e tests.")
     parser.add_argument("-c", "--config",
         choices=config_choices,
@@ -92,11 +93,15 @@ Available options:
 "linalg-mlir-lowering": dump after-pass results in Linalg to LLVM pipeline
 "obj": dump compiled code to object file
 """)
+    parser.add_argument("--use-kernels",
+                        default=False,
+                        action="store_true",
+                        help="Enable linalg ops replacement with runtime library kernel calls.")
     return parser
 
 def main():
     args = _get_argparse().parse_args()
-    opts = TestOptions(dumps=args.dump)
+    opts = TestOptions(dumps=args.dump, use_kernels=args.use_kernels)
 
     all_test_unique_names = set(
         test.unique_name for test in GLOBAL_TEST_REGISTRY)
@@ -128,6 +133,10 @@ def main():
         crashing_set = LTC_CRASHING_SET
     elif args.config == "torchdynamo":
         config = TorchDynamoTestConfig(RefBackendLinalgOnTensorsBackend(), opts=opts)
+        xfail_set = TORCHDYNAMO_XFAIL_SET
+        crashing_set = TORCHDYNAMO_CRASHING_SET
+    elif args.config == "cpuproto":
+        config = TorchDynamoTestConfig(CpuProtoLinalgOnTensorsBackend(opts), opts=opts)
         xfail_set = TORCHDYNAMO_XFAIL_SET
         crashing_set = TORCHDYNAMO_CRASHING_SET
 

--- a/projects/pt1/examples/mlp.py
+++ b/projects/pt1/examples/mlp.py
@@ -1,0 +1,40 @@
+import torch
+import torch_mlir
+from torch_mlir_e2e_test.framework import TraceItem
+from torch_mlir_e2e_test.configs.torchdynamo import TorchDynamoTestConfig
+from torch_mlir_e2e_test.linalg_on_tensors_backends.refbackend import (
+    RefBackendLinalgOnTensorsBackend,
+)
+
+
+class MLP(torch.nn.Module):
+    def __init__(self, input_dim, output_dim):
+        super().__init__()
+        self.flatten = torch.nn.Flatten()
+        self.linear1 = torch.nn.Linear(input_dim, input_dim // 2)
+        self.relu = torch.nn.ReLU()
+        self.linear2 = torch.nn.Linear(input_dim // 2, output_dim)
+
+    def forward(self, x):
+        x = self.flatten(x)
+        x = self.linear1(x)
+        x = self.relu(x)
+        x = self.linear2(x)
+        return x
+
+
+def model_factory():
+    return MLP(16, 2)
+
+
+torch.set_default_dtype(torch.float16)
+model = model_factory()
+test_input = torch.rand(2, 4, 4)
+
+ref_res = [TraceItem(symbol="mlp", inputs=[test_input], output=model(test_input))]
+
+config = TorchDynamoTestConfig(RefBackendLinalgOnTensorsBackend())
+exp_res = config.run(model, ref_res)
+
+print(ref_res[0].output)
+print(exp_res[0].output)

--- a/projects/pt1/python/torch_mlir/__init__.py
+++ b/projects/pt1/python/torch_mlir/__init__.py
@@ -268,7 +268,7 @@ def _canon_extra_library(extra_library):
     return extra_library_file_name
 
 
-def _lower_mlir_module(verbose, output_type, module):
+def _lower_mlir_module(verbose, output_type, module, ir_dump_file = None):
     if verbose:
         print("\n====================")
         print("Torch Backend IR")
@@ -280,7 +280,7 @@ def _lower_mlir_module(verbose, output_type, module):
     if output_type == OutputType.TOSA:
         run_pipeline_with_repro_report(
             module, "builtin.module(torch-backend-to-tosa-backend-pipeline)",
-            "Lowering Torch Backend IR -> TOSA Backend IR")
+            "Lowering Torch Backend IR -> TOSA Backend IR", ir_dump_file)
         if verbose:
             print("\n====================")
             print("TOSA Backend IR")
@@ -291,7 +291,7 @@ def _lower_mlir_module(verbose, output_type, module):
         run_pipeline_with_repro_report(
             module,
             "builtin.module(torch-backend-to-linalg-on-tensors-backend-pipeline)",
-            "Lowering Torch Backend IR -> Linalg-on-Tensors Backend IR")
+            "Lowering Torch Backend IR -> Linalg-on-Tensors Backend IR", ir_dump_file)
         if verbose:
             print("\n====================")
             print("LINALG Backend IR")
@@ -302,7 +302,7 @@ def _lower_mlir_module(verbose, output_type, module):
         run_pipeline_with_repro_report(
             module,
             "builtin.module(torch-backend-to-stablehlo-backend-pipeline)",
-            "Lowering Torch Backend IR -> StableHLO Backend IR")
+            "Lowering Torch Backend IR -> StableHLO Backend IR", ir_dump_file)
         if verbose:
             print("\n====================")
             print("StableHLO Backend IR")

--- a/projects/pt1/python/torch_mlir_e2e_test/framework.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/framework.py
@@ -95,6 +95,17 @@ def clone_trace(trace: Trace) -> Trace:
 # this type.
 CompiledArtifact = TypeVar('CompiledArtifact')
 
+class TestOptions:
+    """Test run options."""
+
+    dump_choices = ["all", "fx-graph", "torch-mlir", "linalg-mlir", "llvm-mlir", "torch-mlir-lowering", "linalg-mlir-lowering", "obj"]
+
+    def __init__(self, dumps: List[str] = []):
+        self.dumps = {opt for opt in dumps}
+
+    def is_dump_enabled(self, dump: str):
+        return dump in self.dumps or "all" in self.dumps
+
 class TestConfig(abc.ABC):
     """The interface implemented by backends to run tests.
 

--- a/projects/pt1/python/torch_mlir_e2e_test/framework.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/framework.py
@@ -100,8 +100,9 @@ class TestOptions:
 
     dump_choices = ["all", "fx-graph", "torch-mlir", "linalg-mlir", "llvm-mlir", "torch-mlir-lowering", "linalg-mlir-lowering", "obj"]
 
-    def __init__(self, dumps: List[str] = []):
+    def __init__(self, *, dumps: List[str] = [], use_kernels=False):
         self.dumps = {opt for opt in dumps}
+        self.use_kernels = use_kernels
 
     def is_dump_enabled(self, dump: str):
         return dump in self.dumps or "all" in self.dumps

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
@@ -10,7 +10,7 @@ from torch_mlir.passmanager import *
 from torch_mlir.execution_engine import *
 from torch_mlir.runtime import *
 from torch_mlir.compiler_utils import run_pipeline_with_repro_report
-from torch_mlir_e2e_test.framework import TestOptions
+from torch_mlir_e2e_test.framework import TestOptions, DebugTimer
 
 from .abc import LinalgOnTensorsBackend
 from .refbackend import RefBackendInvoker
@@ -118,14 +118,15 @@ class CpuProtoLinalgOnTensorsBackend(LinalgOnTensorsBackend):
           An opaque, backend specific compiled artifact object that can be
           passed to `load`.
         """
-
-        run_pipeline_with_repro_report(
-            imported_module, _build_lowering_pipeline(self._opts),
-            "Lowering Linalg-on-Tensors IR to LLVM with RefBackend", ir_file)
+        with DebugTimer('CpuProtoLinalgOnTensorsBackend.compile()', logger=print if self._opts.debug_timer else None):
+            run_pipeline_with_repro_report(
+                imported_module, _build_lowering_pipeline(self._opts),
+                "Lowering Linalg-on-Tensors IR to LLVM with RefBackend", ir_file)
         return imported_module
 
     def load(self, module) -> RefBackendInvoker:
         """Loads a compiled artifact into the runtime."""
-
-        return RefBackendInvoker(module,
-                                 shared_libs=_collect_shared_libs(self._opts))
+        with DebugTimer('CpuProtoLinalgOnTensorsBackend.load()', logger=print if self._opts.debug_timer else None):
+            invoker = RefBackendInvoker(module,
+                                    shared_libs=_collect_shared_libs(self._opts))
+        return invoker

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
@@ -128,5 +128,5 @@ class CpuProtoLinalgOnTensorsBackend(LinalgOnTensorsBackend):
         """Loads a compiled artifact into the runtime."""
         with DebugTimer('CpuProtoLinalgOnTensorsBackend.load()', logger=print if self._opts.debug_timer else None):
             invoker = RefBackendInvoker(module,
-                                    shared_libs=_collect_shared_libs(self._opts))
+                                    shared_libs=_collect_shared_libs(self._opts), logger=print if self._opts.debug_timer else None)
         return invoker

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
@@ -22,6 +22,7 @@ __all__ = [
 
 def _build_lowering_pipeline(opts: TestOptions):
     passes = [
+        "fuse-linalg-ops",
         "func.func(refback-generalize-tensor-pad)",
         # Apply some optimizations. It would be great if MLIR had more useful
         # optimizations that worked out of the box here.

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
@@ -34,6 +34,7 @@ def _build_lowering_pipeline(opts: TestOptions):
         "func.func(linalg-fuse-elementwise-ops)",
         "convert-shape-to-std",
         # Bufferize.
+        "one-shot-bufferize",
         "func.func(scf-bufferize)",
         "func.func(tm-tensor-bufferize)",
         "func.func(empty-tensor-to-alloc-tensor)",
@@ -43,7 +44,13 @@ def _build_lowering_pipeline(opts: TestOptions):
         "refback-mlprogram-bufferize",
         "func.func(tensor-bufferize)",
         "func.func(finalizing-bufferize)",
-        "func.func(buffer-deallocation)",
+        #"func.func(buffer-deallocation)",
+        "ownership-based-buffer-deallocation",
+        "canonicalize",
+        "buffer-deallocation-simplification",
+        "bufferization-lower-deallocations",
+        "cse",
+        "canonicalize",
         # Munge to make it ExecutionEngine compatible.
         # Specifically, we rewrite calling convention boundaries to be in terms
         # of unranked memref, and we rewrite the return to actually be a

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
@@ -1,0 +1,131 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+import os
+
+from torch_mlir.ir import *
+from torch_mlir.passmanager import *
+from torch_mlir.execution_engine import *
+from torch_mlir.runtime import *
+from torch_mlir.compiler_utils import run_pipeline_with_repro_report
+from torch_mlir_e2e_test.framework import TestOptions
+
+from .abc import LinalgOnTensorsBackend
+from .refbackend import RefBackendInvoker
+
+__all__ = [
+    "CpuProtoLinalgOnTensorsBackend",
+]
+
+
+def _build_lowering_pipeline(opts: TestOptions):
+    passes = [
+        "func.func(refback-generalize-tensor-pad)",
+        # Apply some optimizations. It would be great if MLIR had more useful
+        # optimizations that worked out of the box here.
+        # Note: When measured, this doesn't seem to actually help that much
+        # for the linalg-on-tensors backend.
+        # This is likely because if things are naturally fusable we usually already
+        # emit things in that form from the high level (e.g. single linalg-generic).
+        # Other backends are likely to benefit more.
+        "func.func(linalg-fuse-elementwise-ops)",
+        "convert-shape-to-std",
+        # Bufferize.
+        "func.func(scf-bufferize)",
+        "func.func(tm-tensor-bufferize)",
+        "func.func(empty-tensor-to-alloc-tensor)",
+        "func.func(linalg-bufferize)",
+        "func-bufferize",
+        "arith-bufferize",
+        "refback-mlprogram-bufferize",
+        "func.func(tensor-bufferize)",
+        "func.func(finalizing-bufferize)",
+        "func.func(buffer-deallocation)",
+        # Munge to make it ExecutionEngine compatible.
+        # Specifically, we rewrite calling convention boundaries to be in terms
+        # of unranked memref, and we rewrite the return to actually be a
+        # callback that consumes the return (the final munged function always
+        # returns void at the C level -- we get the return value by providing the
+        # callback).
+        "refback-munge-calling-conventions"
+    ]
+    if opts.use_kernels:
+        # Introduce kernel calls for operations we want to execute using library
+        # kernels.
+        passes.append("convert-linalg-ops-to-kernel-calls")
+    passes.extend([
+        # Insert global variable and instruction sequence for getting the next
+        # global seed used in stateful rng.
+        # Lower to LLVM
+        "func.func(tm-tensor-to-loops)",
+        "func.func(refback-munge-memref-copy)",
+        "func.func(convert-linalg-to-loops)",
+        "func.func(lower-affine)",
+        "convert-scf-to-cf",
+        "func.func(refback-expand-ops-for-llvm)",
+        "func.func(arith-expand)",
+        "func.func(convert-math-to-llvm)",
+        # Handle some complex mlir::math ops (e.g. atan2)
+        "convert-math-to-libm",
+        "expand-strided-metadata",
+        "finalize-memref-to-llvm",
+        "lower-affine",
+        "convert-bufferization-to-memref",
+        "finalize-memref-to-llvm",
+        "func.func(convert-arith-to-llvm)",
+        "convert-func-to-llvm",
+        "convert-cf-to-llvm",
+        "convert-complex-to-llvm",
+        "reconcile-unrealized-casts"
+    ])
+    return "builtin.module(" + ",".join(passes) + ")"
+
+
+def _find_shared_lib(name):
+    this_file_dir = os.path.dirname(os.path.abspath(__file__))
+    lib_file_path = f"{this_file_dir}/../../torch_mlir/_mlir_libs/{name}"
+    if not os.path.isfile(lib_file_path):
+        raise RuntimeError(f"Cannot find runtime library: {lib_file_path}")
+    return lib_file_path
+
+
+def _collect_shared_libs(opts: TestOptions):
+    shared_libs = []
+    if opts.use_kernels:
+        shared_libs.append(_find_shared_lib("libTorchMLIRKernels.so"))
+    return shared_libs
+
+
+class CpuProtoLinalgOnTensorsBackend(LinalgOnTensorsBackend):
+    """Main entry-point for the reference backend."""
+    def __init__(self, opts: TestOptions = TestOptions()):
+        super().__init__()
+        self._opts = opts
+
+    def compile(self, imported_module: Module, ir_file: str = None):
+        """Compiles an imported module, with a flat list of functions.
+        The module is expected to be in linalg-on-tensors + scalar code form.
+        TODO: More clearly define the backend contract. Generally this will
+        extend to support globals, lists, and other stuff.
+
+        Args:
+          imported_module: The MLIR module consisting of funcs in the torch
+            dialect.
+          ir_file: If specified, use it as output file for MLIR passes dumps
+        Returns:
+          An opaque, backend specific compiled artifact object that can be
+          passed to `load`.
+        """
+
+        run_pipeline_with_repro_report(
+            imported_module, _build_lowering_pipeline(self._opts),
+            "Lowering Linalg-on-Tensors IR to LLVM with RefBackend", ir_file)
+        return imported_module
+
+    def load(self, module) -> RefBackendInvoker:
+        """Loads a compiled artifact into the runtime."""
+
+        return RefBackendInvoker(module,
+                                 shared_libs=_collect_shared_libs(self._opts))

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -182,7 +182,7 @@ class RefBackendLinalgOnTensorsBackend(LinalgOnTensorsBackend):
     def __init__(self):
         super().__init__()
 
-    def compile(self, imported_module: Module):
+    def compile(self, imported_module: Module, ir_file: str = None):
         """Compiles an imported module, with a flat list of functions.
         The module is expected to be in linalg-on-tensors + scalar code form.
         TODO: More clearly define the backend contract. Generally this will
@@ -198,7 +198,7 @@ class RefBackendLinalgOnTensorsBackend(LinalgOnTensorsBackend):
 
         run_pipeline_with_repro_report(
             imported_module, LOWERING_PIPELINE,
-            "Lowering Linalg-on-Tensors IR to LLVM with RefBackend")
+            "Lowering Linalg-on-Tensors IR to LLVM with RefBackend", ir_file)
         return imported_module
 
     def load(self, module) -> RefBackendInvoker:

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -80,8 +80,8 @@ def get_ctype_func(func_name):
 
 class RefBackendInvoker:
 
-    def __init__(self, module):
-        self.ee = ExecutionEngine(module)
+    def __init__(self, module, shared_libs=None):
+        self.ee = ExecutionEngine(module, shared_libs=shared_libs)
         self.result = None
 
         return_funcs = get_return_funcs(module)

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/mlp.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/mlp.py
@@ -99,3 +99,44 @@ class BatchMlpLayerModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: BatchMlpLayerModule())
 def BatchMlpLayerModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(7, 5, 3))
+
+
+class MLP(torch.nn.Module):
+    def __init__(self, input_dim, output_dim):
+        super().__init__()
+        self.flatten = torch.nn.Flatten()
+        self.linear1 = torch.nn.Linear(input_dim, input_dim // 2)
+        # self.relu = torch.nn.ReLU()
+        # self.linear2 = torch.nn.Linear(input_dim // 2, output_dim)
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        x = self.flatten(x)
+        x = self.linear1(x)
+        # x = self.relu(x)
+        # x = self.linear2(x)
+        return x
+
+model = MLP(128 * 128, 0)
+
+def model_factory():
+    return model
+
+
+test_input = torch.rand(1, 128, 128)
+w = model.linear1.weight.detach().numpy()
+b = model.linear1.bias.detach().numpy()
+print("in shape: ", test_input.shape)
+print(" w shape: ", w.shape)
+print(" b shape: ", b.shape)
+
+
+@register_test_case(module_factory=model_factory)
+def MLP_basic(module, tu: TestUtils):
+    out = module.forward(test_input)
+    print("[test body] out shape: ", out.size())
+


### PR DESCRIPTION
This commit enables oneshot bufferization and associated passes.
Amount of mallocs reduced, but correctness should be verified on bigger
amount of nets/layers.

in shape:  torch.Size([100, 128, 128])
 w shape:  (8192, 16384)
 b shape:  (8192,)

vanilla pytorch
```
1.20438 ms = (1.3544 + 1.2414 + 1.1625 + 1.2506 + 1.1141 + 1.1030 + 1.1984 + 1.2178 + 1.2174 + 1.1842)/10
```
toch_mlir
```
4.60667 ms = (5.7596 + 4.8763 + 6.0515 + 4.1456 + 4.3975 + 4.2410 + 4.2244 + 4.1725 + 4.2603 + 3.9380)/10
```
toch_mlir oneshot
```
3.86755 ms = (3.8856 + 3.5017 + 3.6128 + 3.5422 + 4.7873 + 3.6021 + 3.5291 + 3.5989 + 3.6128 + 5.0030)/10
```

```python
x = self.flatten(x)
x = self.linear1(x)
x = self.relu(x)
x = self.linear2(x)

MLP(128 * 128, 1024)
```

```
current - memref.alloc() - 6 ops
oneshot - memref.alloc() - 3 ops
```
