### PR TITLE
Revert "Fix a typo (#16)"

### DIFF
--- a/utils/level-zero-runtime-log.patch
+++ b/utils/level-zero-runtime-log.patch
@@ -44,7 +44,7 @@ index ccf2258..edf807e 100644
    desc.inputSize = dataSize;
    desc.pBuildFlags = build_flags;
    CHECK_ZE_RESULT(zeModuleCreate(gpuL0Queue->zeContext_, gpuL0Queue->zeDevice_,
-                                  &desc, &zeModule, buildlog));
+                                  &desc, &zeModule, nullptr));
 +  size_t logSize = 0;
 +  CHECK_ZE_RESULT(zeModuleBuildLogGetString(buildlog, &logSize, nullptr));
 +  std::string strLog(logSize, ' ');


### PR DESCRIPTION
This reverts commit 7b8371d96cadcac7ea11854d3bc7b76a853a5903. #16 breaks the build because the modified patch doesn't apply.