### PR TITLE
Enable Resnet compilation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "externals/stablehlo"]
 	path = externals/stablehlo
 	url = https://github.com/openxla/stablehlo.git
+[submodule "externals/mlir-extensions"]
+	path = externals/mlir-extensions
+	url = git@github.com:intel/mlir-extensions.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/openxla/stablehlo.git
 [submodule "externals/mlir-extensions"]
 	path = externals/mlir-extensions
-	url = git@github.com:intel/mlir-extensions.git
+	url = https://github.com/intel/mlir-extensions.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "externals/mlir-extensions"]
 	path = externals/mlir-extensions
 	url = https://github.com/intel/mlir-extensions.git
+[submodule "externals/tpp-mlir"]
+	path = externals/tpp-mlir
+	url = https://github.com/intel-ai/tpp-mlir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,8 +112,12 @@ else()
   # TODO: Fix this upstream so that global include directories are not needed.
   set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir)
   set(MLIR_INCLUDE_DIR ${LLVM_MAIN_SRC_DIR}/../mlir/include)
+  set(IMEX_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../../mlir-extensions)
+  set(IMEX_INCLUDE_DIR ${LLVM_MAIN_SRC_DIR}/../../mlir-extensions/include)
+  set(IMEX_GENERATED_INCLUDE_DIR ${LLVM_BINARY_DIR}/tools/Imex/include)
   set(MLIR_GENERATED_INCLUDE_DIR ${LLVM_BINARY_DIR}/tools/mlir/include)
-  set(MLIR_INCLUDE_DIRS "${MLIR_INCLUDE_DIR};${MLIR_GENERATED_INCLUDE_DIR}")
+  set(IMEX_INCLUDE_DIRS "${IMEX_INCLUDE_DIR};${IMEX_GENERATED_INCLUDE_DIR}")
+  set(MLIR_INCLUDE_DIRS "${MLIR_INCLUDE_DIR};${MLIR_GENERATED_INCLUDE_DIR};${IMEX_INCLUDE_DIRS}")
 endif()
 
 if (TORCH_MLIR_ENABLE_STABLEHLO)
@@ -128,12 +132,15 @@ include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/../Imex/include)
 
 function(torch_mlir_target_includes target)
   set(_dirs
     $<BUILD_INTERFACE:${MLIR_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${TORCH_MLIR_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${TORCH_MLIR_BINARY_DIR}/include>
+    $<BUILD_INTERFACE:${TORCH_MLIR_BINARY_DIR}/../Imex/include>
   )
   # In LLVM parlance, the actual target may just be an interface and may not
   # be responsible for actually compiling anything. The corresponding obj.
@@ -149,6 +156,13 @@ endfunction()
 # Configure CMake.
 list(APPEND CMAKE_MODULE_PATH ${MLIR_MAIN_SRC_DIR}/cmake/modules)
 list(APPEND CMAKE_MODULE_PATH ${LLVM_MAIN_SRC_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${IMEX_MAIN_SRC_DIR}/cmake/modules)
+
+get_property(IMEX_LIBS GLOBAL PROPERTY IMEX_ALL_LIBS)
+message(STATUS "${TORCH_MLIR_BINARY_DIR}/tools/Imex/include")
+message(STATUS "${CMAKE_CURRENT_BINARY_DIR}/../Imex/include")
+message(STATUS "IMEX_LIBS: ${IMEX_LIBS}")
+# message(FATAL_ERROR "IMEX_INCLUDE_DIRS: ${IMEX_INCLUDE_DIRS}")
 
 include(TableGen)
 include(AddLLVM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,13 +163,6 @@ if(MLIR_ENABLE_BINDINGS_PYTHON)
   mlir_configure_python_dev_packages()
 endif()
 
-add_subdirectory(include)
-add_subdirectory(lib)
-add_subdirectory(tools)
-
-add_custom_target(check-torch-mlir-all)
-add_dependencies(check-torch-mlir-all check-torch-mlir)
-
 if(MLIR_ENABLE_BINDINGS_PYTHON)
   # If parent projects want to configure where to place the python packages,
   # respect that.
@@ -177,6 +170,13 @@ if(MLIR_ENABLE_BINDINGS_PYTHON)
     set(TORCH_MLIR_PYTHON_PACKAGES_DIR "${CMAKE_CURRENT_BINARY_DIR}/python_packages")
   endif()
 endif()
+
+add_subdirectory(include)
+add_subdirectory(lib)
+add_subdirectory(tools)
+
+add_custom_target(check-torch-mlir-all)
+add_dependencies(check-torch-mlir-all check-torch-mlir)
 
 add_subdirectory(test)
 

--- a/conda-dev-env.yml
+++ b/conda-dev-env.yml
@@ -1,0 +1,21 @@
+#  To create environment, execute:
+#     conda env create -f conda-dev-env.yml
+#
+#  To activate:
+#     conda activate mlir-dev
+#
+name: mlir-dev
+channels:
+  - conda-forge
+
+dependencies:
+  - gxx_linux-64   12.*
+  - gcc_linux-64   12.*
+  - ccache
+  - sysroot_linux-64 >=2.14
+  - llvmdev     16.*
+  - cmake
+  - make
+  - llvm
+  - python      ==3.11
+  - mkl

--- a/conda-dev-env.yml
+++ b/conda-dev-env.yml
@@ -18,3 +18,4 @@ dependencies:
   - python      ==3.11
   - level-zero-devel
   - git
+  - llvm-openmp

--- a/conda-dev-env.yml
+++ b/conda-dev-env.yml
@@ -13,9 +13,8 @@ dependencies:
   - gcc_linux-64   12.*
   - ccache
   - sysroot_linux-64 >=2.14
-  - llvmdev     16.*
   - cmake
-  - make
-  - llvm
+  - ninja
   - python      ==3.11
-  - mkl
+  - level-zero-devel
+  - git

--- a/include/torch-mlir/Conversion/FuseLinalg/FuseLinalg.h
+++ b/include/torch-mlir/Conversion/FuseLinalg/FuseLinalg.h
@@ -1,0 +1,16 @@
+#ifndef TORCHMLIR_FUSE_LINALG_H
+#define TORCHMLIR_FUSE_LINALG_H
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace mlir {
+namespace torch {
+std::unique_ptr<mlir::OperationPass<ModuleOp>> createFuseLinalgOpsPass();
+}
+} // namespace mlir
+
+#endif // TORCHMLIR_FUSE_LINALG_H

--- a/include/torch-mlir/Conversion/LinalgToKernelCalls/LinalgToKernelCalls.h
+++ b/include/torch-mlir/Conversion/LinalgToKernelCalls/LinalgToKernelCalls.h
@@ -1,0 +1,25 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TORCHMLIR_CONVERSION_LINALGTOKERNELCALLS_LINALGTOKERNELCALLS_H
+#define TORCHMLIR_CONVERSION_LINALGTOKERNELCALLS_LINALGTOKERNELCALLS_H
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace mlir {
+namespace torch {
+std::unique_ptr<OperationPass<ModuleOp>>
+createConvertLinalgOpsToKernelCallsPass();
+}
+} // namespace mlir
+
+#endif // TORCHMLIR_CONVERSION_LINALGTOKERNELCALLS_LINALGTOKERNELCALLS_H

--- a/include/torch-mlir/Conversion/Passes.td
+++ b/include/torch-mlir/Conversion/Passes.td
@@ -154,4 +154,15 @@ def ConvertTorchToStablehlo : Pass<"convert-torch-to-stablehlo", "func::FuncOp">
 }
 #endif
 
+def ConvertLinalgOpsToKernelCalls
+    : Pass<"convert-linalg-ops-to-kernel-calls", "ModuleOp"> {
+  let summary = "Lower linalg.matmul operation to kernel call.";
+  let constructor = [{
+    mlir::torch::createConvertLinalgOpsToKernelCallsPass()
+  }];
+  let description = [{
+    This pass replaces linalg.matmul operations with calls to the runtime library.
+  }];
+}
+
 #endif // TORCHMLIR_CONVERSION_PASSES

--- a/include/torch-mlir/Conversion/Passes.td
+++ b/include/torch-mlir/Conversion/Passes.td
@@ -165,4 +165,15 @@ def ConvertLinalgOpsToKernelCalls
   }];
 }
 
+def FuseLinalgOps
+    : Pass<"fuse-linalg-ops", "ModuleOp"> {
+  let summary = "Fuse linalg operations.";
+  let constructor = [{
+    mlir::torch::createFuseLinalgOpsPass()
+  }];
+  let description = [{
+    This pass fuses linalg ops.
+  }];
+}
+
 #endif // TORCHMLIR_CONVERSION_PASSES

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -14,6 +14,16 @@ set(LinkedLibs
   MLIRTensorDialect
   MLIRTosaDialect
   MLIRSupport
+  MLIRLinalgTransformOps
+  MLIRTensorTransformOps
+  MLIROpenACCToLLVMIRTranslation
+  MLIROpenMPToLLVMIRTranslation
+  MLIRX86VectorToLLVMIRTranslation
+  MLIRAMXToLLVMIRTranslation
+  MLIRArmNeonToLLVMIRTranslation
+  MLIRArmSMEToLLVMIRTranslation
+  MLIRArmSVEToLLVMIRTranslation
+  MLIRSPIRVToLLVMIRTranslation
 
   MLIRGPUDialect
   MLIRGPUTransforms
@@ -52,6 +62,25 @@ set(LinkedLibs
   TorchMLIRTMTensorDialect
 
   TorchMLIRConversionPasses
+
+  TPPIR
+  TPPPipeline
+  TPPTransforms
+  TPPTppDialect
+  TPPLinalgXTransformOps
+  TPPXsmmDialect
+  TPPCheckToLoops
+  TPPLinalgToFunc
+  TPPLinalgToTpp
+  TPPLinalgToXSMM
+  TPPMemRefToXSMM
+  TPPPerfToFunc
+  TPPPerfToLoop
+  TPPTppToLoops
+  TPPTppToXSMM
+  TPPXsmmToFunc
+  TPPTestLib
+  xsmm
 )
 
 if(TORCH_MLIR_ENABLE_REFBACKEND)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,6 +15,33 @@ set(LinkedLibs
   MLIRTosaDialect
   MLIRSupport
 
+  MLIRGPUDialect
+  MLIRGPUTransforms
+  MLIRSPIRVDialect
+  MLIRAsyncToLLVM
+
+  IMEXPTensorDialect
+  IMEXDistDialect
+  IMEXGPUXDialect
+  IMEXXeTileDialect
+  IMEXXeGPUDialect
+
+  IMEXPTensorTransforms
+  IMEXXeTileTransforms
+  IMEXXeGPUTransforms
+
+  IMEXPTensorToLinalg
+  IMEXDistToStandard
+  IMEXGPUToSPIRV
+  IMEXGPUToGPUX
+  IMEXGPUXToLLVM
+  XeGPUToSPIRV
+  IMEXXeTileToXeGPU
+  
+  MLIROptLib
+  IMEXTransforms
+  IMEXUtil
+
   TorchMLIRTorchPasses
   TorchMLIRTorchConversionDialect
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(CAPI)
 add_subdirectory(Conversion)
 add_subdirectory(Dialect)
+add_subdirectory(Runtime)
 
 set(LinkedLibs
   MLIRComplexDialect

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(LinalgToKernelCalls)
 add_subdirectory(TorchToLinalg)
 add_subdirectory(TorchToSCF)
 add_subdirectory(TorchToArith)
@@ -10,7 +11,8 @@ add_subdirectory(TorchConversionToMLProgram)
 add_subdirectory(Utils)
 
 # TODO: Automate this with add_torch_mlir_conversion_library.
-set(linked_libs TorchMLIRTorchToLinalg
+set(linked_libs TorchMLIRLinalgToKernelCalls
+                TorchMLIRTorchToLinalg
                 TorchMLIRTorchToSCF
                 TorchMLIRTorchToArith
                 TorchMLIRTorchToTosa

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(TorchToLinalg)
 add_subdirectory(TorchToSCF)
 add_subdirectory(TorchToArith)
 add_subdirectory(TorchToTosa)
+add_subdirectory(FuseLinalg)
 if(TORCH_MLIR_ENABLE_STABLEHLO)
   add_subdirectory(TorchToStablehlo)
 endif()
@@ -13,6 +14,7 @@ add_subdirectory(Utils)
 # TODO: Automate this with add_torch_mlir_conversion_library.
 set(linked_libs TorchMLIRLinalgToKernelCalls
                 TorchMLIRTorchToLinalg
+                FuseLinalg
                 TorchMLIRTorchToSCF
                 TorchMLIRTorchToArith
                 TorchMLIRTorchToTosa

--- a/lib/Conversion/FuseLinalg/CMakeLists.txt
+++ b/lib/Conversion/FuseLinalg/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_mlir_conversion_library(FuseLinalg
+  FuseLinalg.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/torch-mlir/Conversion/FuseLinalg
+
+  DEPENDS
+  TorchMLIRConversionPassIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRLinalgDialect
+)
+
+torch_mlir_target_includes(FuseLinalg)

--- a/lib/Conversion/FuseLinalg/FuseLinalg.cpp
+++ b/lib/Conversion/FuseLinalg/FuseLinalg.cpp
@@ -1,0 +1,128 @@
+#include "torch-mlir/Conversion/FuseLinalg/FuseLinalg.h"
+
+#include "../PassDetail.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MLProgram/IR/MLProgram.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include <algorithm>
+
+namespace {
+
+class MatmulTranspose : public mlir::OpRewritePattern<mlir::linalg::MatmulOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  mlir::LogicalResult
+  matchAndRewrite(mlir::linalg::MatmulOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+
+    auto mm_op = mlir::cast<mlir::linalg::MatmulOp>(&op);
+    auto inputs = mm_op->getInputs();
+    std::vector<int32_t> transposed_input_nums;
+    transposed_input_nums.reserve(inputs.size());
+
+    mlir::linalg::TransposeOp transposeOp = nullptr;
+    std::fill_n(std::back_inserter(transposed_input_nums), inputs.size(), -1);
+    if (transposed_input_nums.size() != 2) {
+      return rewriter.notifyMatchFailure(
+          op, "Inputs amount is not common for Matmul");
+    }
+
+    for (size_t num_input = 0; num_input < inputs.size(); num_input++) {
+      mlir::Value input = inputs[num_input];
+      transposeOp =
+          llvm::dyn_cast<mlir::linalg::TransposeOp>(input.getDefiningOp());
+      if (!transposeOp) {
+        continue;
+      }
+      transposed_input_nums[num_input] = num_input;
+    }
+
+    const int default_inps = std::count(transposed_input_nums.cbegin(),
+                                        transposed_input_nums.cend(), -1);
+    if (default_inps != 1) {
+      return rewriter.notifyMatchFailure(op, "Both Inputs is Transposed");
+    }
+
+    if (!transposeOp) {
+      return rewriter.notifyMatchFailure(op, "Input is not TransposeOp");
+    }
+    /* Maybe we need this
+    if (isListPotential[ERROR] lyMutated(transposeOp.getResult()))
+      return rewriter.notifyMatchFailure(
+          op, "TransposeOp result is potentially mutated");
+    */
+
+    mlir::Location loc = op.getLoc();
+
+    mlir::SmallVector<mlir::Value> fusedInputOperands, fusedOutputOperands;
+    mlir::SmallVector<mlir::Type> fusedResultTypes;
+    for (mlir::OpOperand &opOperand : op.getOutputsMutable()) {
+      fusedOutputOperands.push_back(opOperand.get());
+      mlir::Type resultType = opOperand.get().getType();
+      if (!mlir::isa<mlir::MemRefType>(resultType))
+        fusedResultTypes.push_back(resultType);
+    }
+
+    mlir::Value matmul;
+    if (transposed_input_nums[0] != -1) {
+      fusedInputOperands.push_back(transposeOp.getInputMutable().get());
+      fusedInputOperands.push_back(op.getInputsMutable()[1].get());
+
+      auto mm_a = rewriter.create<mlir::linalg::MatmulTransposeAOp>(
+          loc, fusedResultTypes, fusedInputOperands, fusedOutputOperands);
+      matmul = mm_a.getResult(0);
+    } else if (transposed_input_nums[1] != -1) {
+      fusedInputOperands.push_back(op.getInputsMutable()[0].get());
+      fusedInputOperands.push_back(transposeOp.getInputMutable().get());
+
+      auto mm_b = rewriter.create<mlir::linalg::MatmulTransposeBOp>(
+          loc, fusedResultTypes, fusedInputOperands, fusedOutputOperands);
+
+      matmul = mm_b.getResult(0);
+    }
+
+    rewriter.replaceUsesWithIf(
+        op.getResult(0), matmul, [&](mlir::OpOperand &use) {
+          // Only replace consumer uses.
+          return use.get().getDefiningOp() != transposeOp;
+        });
+    rewriter.eraseOp(op);
+
+    if (transposeOp.getResult().use_empty()) {
+      rewriter.eraseOp(transposeOp);
+    } 
+    return mlir::success();
+  }
+};
+
+class FuseLinalgOps : public mlir::torch::FuseLinalgOpsBase<FuseLinalgOps> {
+public:
+  void runOnOperation() override {
+    mlir::MLIRContext *context = &getContext();
+    mlir::RewritePatternSet patterns(context);
+
+    // pattern.add calls go here
+    patterns.add<MatmulTranspose>(context);
+
+    mlir::GreedyRewriteConfig config;
+    config.useTopDownTraversal = true;
+
+    if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns),
+                                            config))) {
+      mlir::emitError(getOperation()->getLoc(), "failure in Linalg fusion");
+      signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
+mlir::torch::createFuseLinalgOpsPass() {
+  return std::make_unique<FuseLinalgOps>();
+}

--- a/lib/Conversion/FuseLinalg/FuseLinalg.cpp
+++ b/lib/Conversion/FuseLinalg/FuseLinalg.cpp
@@ -35,8 +35,9 @@ public:
 
     for (size_t num_input = 0; num_input < inputs.size(); num_input++) {
       mlir::Value input = inputs[num_input];
-      transposeOp =
-          llvm::dyn_cast<mlir::linalg::TransposeOp>(input.getDefiningOp());
+      // If one of inputs is input of whole func it will be nullptr.
+      transposeOp = llvm::dyn_cast_if_present<mlir::linalg::TransposeOp>(
+          input.getDefiningOp());
       if (!transposeOp) {
         continue;
       }
@@ -96,7 +97,7 @@ public:
 
     if (transposeOp.getResult().use_empty()) {
       rewriter.eraseOp(transposeOp);
-    } 
+    }
     return mlir::success();
   }
 };

--- a/lib/Conversion/LinalgToKernelCalls/CMakeLists.txt
+++ b/lib/Conversion/LinalgToKernelCalls/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_mlir_conversion_library(TorchMLIRLinalgToKernelCalls
+  LinalgToKernelCalls.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/torch-mlir/Conversion/TorchToLinalg
+
+  DEPENDS
+  TorchMLIRConversionPassIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRLinalgDialect
+  MLIRMathDialect
+  TorchMLIRTorchDialect
+)
+
+torch_mlir_target_includes(TorchMLIRLinalgToKernelCalls)

--- a/lib/Conversion/LinalgToKernelCalls/LinalgToKernelCalls.cpp
+++ b/lib/Conversion/LinalgToKernelCalls/LinalgToKernelCalls.cpp
@@ -1,0 +1,126 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "torch-mlir/Conversion/LinalgToKernelCalls/LinalgToKernelCalls.h"
+
+#include "../PassDetail.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Complex/IR/Complex.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionDialect.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
+#include "torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
+
+#include <iostream>
+
+using namespace mlir;
+using namespace mlir::torch;
+using namespace mlir::torch::Torch;
+
+namespace {
+LogicalResult
+convertLinalgOpsInFunc(func::FuncOp func,
+                       std::map<std::string, SmallVector<Type>> &usedKernels) {
+  OpBuilder b(func.getBody());
+  SmallVector<Operation *> replacedOps;
+  func.walk([&](linalg::MatmulOp op) {
+    auto types = op.getOperandTypes();
+    auto lhs_type = types[0];
+    auto rhs_type = types[1];
+    auto res_type = types[2];
+    auto lhs_elem_type = lhs_type.cast<BaseMemRefType>().getElementType();
+    auto rhs_elem_type = rhs_type.cast<BaseMemRefType>().getElementType();
+    auto res_elem_type = res_type.cast<BaseMemRefType>().getElementType();
+
+    if (lhs_elem_type != rhs_elem_type || lhs_elem_type != res_elem_type)
+      return;
+
+    if (lhs_type.cast<BaseMemRefType>().getMemorySpace() !=
+            rhs_type.cast<BaseMemRefType>().getMemorySpace() ||
+        lhs_type.cast<BaseMemRefType>().getMemorySpace() !=
+            res_type.cast<BaseMemRefType>().getMemorySpace())
+      return;
+
+    if (!lhs_elem_type.isF16() && !lhs_elem_type.isF32() &&
+        !lhs_elem_type.isF64())
+      return;
+
+    b.setInsertionPoint(op);
+
+    auto unranked_type = UnrankedMemRefType::get(
+        lhs_elem_type, lhs_type.cast<BaseMemRefType>().getMemorySpace());
+    std::string fn_name = "matmul_kernel_";
+    llvm::raw_string_ostream rss(fn_name);
+    lhs_elem_type.print(rss);
+    if (!usedKernels.count(fn_name)) {
+      usedKernels.emplace(
+          fn_name,
+          SmallVector<Type>({unranked_type, unranked_type, unranked_type}));
+    }
+
+    SmallVector<Value> unranked_ops;
+    for (auto op : op.getOperands())
+      unranked_ops.push_back(
+          b.create<memref::CastOp>(op.getLoc(), unranked_type, op));
+    b.create<func::CallOp>(op.getLoc(), fn_name, TypeRange({}), unranked_ops);
+    replacedOps.push_back(op);
+  });
+
+  for (Operation *op : replacedOps)
+    op->erase();
+
+  return success();
+}
+} // namespace
+
+namespace {
+class ConvertLinalgOpsToKernelCalls
+    : public ConvertLinalgOpsToKernelCallsBase<ConvertLinalgOpsToKernelCalls> {
+public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect>();
+    registry.insert<math::MathDialect>();
+    registry.insert<func::FuncDialect>();
+    registry.insert<tensor::TensorDialect>();
+    registry.insert<arith::ArithDialect>();
+    registry.insert<cf::ControlFlowDialect>();
+    registry.insert<complex::ComplexDialect>();
+  }
+
+  void runOnOperation() override {
+    auto module = getOperation();
+    OpBuilder b(module.getBodyRegion());
+    std::map<std::string, SmallVector<Type>> usedKernels;
+    for (auto func : module.getOps<func::FuncOp>()) {
+      if (failed(convertLinalgOpsInFunc(func, usedKernels)))
+        return signalPassFailure();
+    }
+
+    // Create FuncOp for each used kernel function.
+    for (auto &p : usedKernels) {
+      auto kernelFunc = b.create<func::FuncOp>(
+          module.getLoc(), p.first,
+          FunctionType::get(module.getContext(), p.second, {}));
+      kernelFunc.setPrivate();
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::torch::createConvertLinalgOpsToKernelCallsPass() {
+  return std::make_unique<ConvertLinalgOpsToKernelCalls>();
+}

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -20,6 +20,7 @@
 #include "torch-mlir/Conversion/TorchToTosa/TorchToTosa.h"
 #include "torch-mlir/Conversion/TorchToTMTensor/TorchToTMTensor.h"
 #include "torch-mlir/Conversion/TorchConversionToMLProgram/TorchConversionToMLProgram.h"
+#include "torch-mlir/Conversion/FuseLinalg/FuseLinalg.h"
 
 //===----------------------------------------------------------------------===//
 // Pass registration

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -13,6 +13,7 @@
 #include "torch-mlir/Conversion/TorchToStablehlo/TorchToStablehlo.h"
 #endif // TORCH_MLIR_ENABLE_STABLEHLO
 
+#include "torch-mlir/Conversion/LinalgToKernelCalls/LinalgToKernelCalls.h"
 #include "torch-mlir/Conversion/TorchToLinalg/TorchToLinalg.h"
 #include "torch-mlir/Conversion/TorchToSCF/TorchToSCF.h"
 #include "torch-mlir/Conversion/TorchToArith/TorchToArith.h"

--- a/lib/InitAll.cpp
+++ b/lib/InitAll.cpp
@@ -13,12 +13,15 @@
 #include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/TransformOps/DialectExtension.h"
 #include "mlir/Dialect/MLProgram/IR/MLProgram.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/TransformOps/TensorTransformOps.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/IR/Dialect.h"
+#include "mlir/Target/LLVMIR/Dialect/All.h"
 #include "torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorDialect.h"
 #include "torch-mlir-dialects/Dialect/TMTensor/Transforms/Passes.h"
 #include "torch-mlir/Conversion/Passes.h"
@@ -38,6 +41,16 @@
 #include "imex/Transforms/Passes.h"
 #include "mlir/Dialect/Func/Extensions/AllExtensions.h"
 
+#include "TPP/Dialect/Check/BufferizableOpInterfaceImpl.h"
+#include "TPP/Dialect/Check/CheckDialect.h"
+#include "TPP/Dialect/Perf/BufferizableOpInterfaceImpl.h"
+#include "TPP/Dialect/Perf/PerfDialect.h"
+#include "TPP/Dialect/Tpp/BufferizableOpInterfaceImpl.h"
+#include "TPP/Dialect/Tpp/TppDialect.h"
+#include "TPP/Dialect/Transform/LinalgXTransformOps.h"
+#include "TPP/Dialect/Xsmm/XsmmDialect.h"
+#include "TPP/Passes.h"
+
 void mlir::torch::registerAllDialects(mlir::DialectRegistry &registry) {
   registry.insert<mlir::func::FuncDialect>();
   registry.insert<mlir::torch::Torch::TorchDialect>();
@@ -45,6 +58,23 @@ void mlir::torch::registerAllDialects(mlir::DialectRegistry &registry) {
   registry.insert<mlir::torch::TMTensor::TMTensorDialect>();
   ::imex::registerAllDialects(registry);
   mlir::func::registerInlinerExtension(registry);
+
+  registry.insert<mlir::tpp::TppDialect>();
+  registry.insert<mlir::xsmm::XsmmDialect>();
+  registry.insert<mlir::check::CheckDialect>();
+  registry.insert<mlir::perf::PerfDialect>();
+  mlir::linalgx::registerTransformDialectExtension(registry);
+  mlir::check::registerBufferizableOpInterfaceExternalModels(registry);
+  mlir::perf::registerBufferizableOpInterfaceExternalModels(registry);
+  mlir::tpp::registerBufferizableOpInterfaceExternalModels(registry);
+
+  // Add the following to include *all* MLIR Core dialects, or selectively
+  // include what you need like above. You only need to register dialects that
+  // will be *parsed* by the tool, not the one generated.
+  registerAllDialects(registry);
+  mlir::linalg::registerTransformDialectExtension(registry);
+  mlir::tensor::registerTransformDialectExtension(registry);
+  registerAllToLLVMIRTranslations(registry);
 }
 
 // TODO: Break this up when backends are separated.
@@ -65,6 +95,9 @@ void mlir::torch::registerAllPasses() {
   mlir::torch::TMTensor::registerPasses();
 
   ::imex::registerAllPasses();
+  mlir::tpp::registerTppCompilerPasses();
+  mlir::tpp::registerTestStructuralMatchers();
+  mlir::tpp::registerTestForToForAllRewrite();
 
 #ifdef TORCH_MLIR_ENABLE_REFBACKEND
   mlir::torch::RefBackend::registerRefBackendPasses();

--- a/lib/InitAll.cpp
+++ b/lib/InitAll.cpp
@@ -28,11 +28,22 @@
 #include "torch-mlir/Dialect/TorchConversion/Transforms/Passes.h"
 #include "torch-mlir/RefBackend/Passes.h"
 
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
+
+#include "imex/Conversion/Passes.h"
+#include "imex/InitIMEXDialects.h"
+#include "imex/InitIMEXPasses.h"
+#include "imex/Transforms/Passes.h"
+#include "mlir/Dialect/Func/Extensions/AllExtensions.h"
+
 void mlir::torch::registerAllDialects(mlir::DialectRegistry &registry) {
   registry.insert<mlir::func::FuncDialect>();
   registry.insert<mlir::torch::Torch::TorchDialect>();
   registry.insert<mlir::torch::TorchConversion::TorchConversionDialect>();
   registry.insert<mlir::torch::TMTensor::TMTensorDialect>();
+  ::imex::registerAllDialects(registry);
   mlir::func::registerInlinerExtension(registry);
 }
 
@@ -42,6 +53,8 @@ void mlir::torch::registerOptionalInputDialects(
   registry.insert<complex::ComplexDialect, linalg::LinalgDialect,
                   memref::MemRefDialect, ml_program::MLProgramDialect,
                   scf::SCFDialect, tensor::TensorDialect, tosa::TosaDialect>();
+  registry
+      .insert<gpu::GPUDialect, spirv::SPIRVDialect, affine::AffineDialect>();
 }
 
 void mlir::torch::registerAllPasses() {
@@ -50,6 +63,8 @@ void mlir::torch::registerAllPasses() {
 
   mlir::torch::registerConversionPasses();
   mlir::torch::TMTensor::registerPasses();
+
+  ::imex::registerAllPasses();
 
 #ifdef TORCH_MLIR_ENABLE_REFBACKEND
   mlir::torch::RefBackend::registerRefBackendPasses();

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -1,10 +1,11 @@
+set(MKL_LINK "static")
 find_package(MKL CONFIG REQUIRED)
 
 add_library(TorchMLIRKernels SHARED Kernels.cpp)
 
 target_compile_options(TorchMLIRKernels PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>)
 target_include_directories(TorchMLIRKernels PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>)
-target_link_libraries(TorchMLIRKernels PUBLIC $<LINK_ONLY:MKL::MKL>)
+target_link_libraries(TorchMLIRKernels PRIVATE $<LINK_ONLY:MKL::MKL>)
 
 set_target_properties(TorchMLIRKernels PROPERTIES
          LIBRARY_OUTPUT_DIRECTORY "${TORCH_MLIR_PYTHON_PACKAGES_DIR}/torch_mlir/torch_mlir/_mlir_libs")

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -1,0 +1,10 @@
+find_package(MKL CONFIG REQUIRED)
+
+add_library(TorchMLIRKernels SHARED Kernels.cpp)
+
+target_compile_options(TorchMLIRKernels PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>)
+target_include_directories(TorchMLIRKernels PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>)
+target_link_libraries(TorchMLIRKernels PUBLIC $<LINK_ONLY:MKL::MKL>)
+
+set_target_properties(TorchMLIRKernels PROPERTIES
+         LIBRARY_OUTPUT_DIRECTORY "${TORCH_MLIR_PYTHON_PACKAGES_DIR}/torch_mlir/torch_mlir/_mlir_libs")

--- a/lib/Runtime/Kernels.cpp
+++ b/lib/Runtime/Kernels.cpp
@@ -72,6 +72,41 @@ extern "C" void matmul_kernel_f32(int64_t lhs_rank, tensor<float> *lhs,
               lhs->data, k, rhs->data, n, beta, res->data, n);
 }
 
+extern "C" void
+matmul_transpose_b_kernel_f32(int64_t lhs_rank, tensor<float> *lhs,
+                              int64_t rhs_rank, tensor<float> *rhs,
+                              int64_t res_rank, tensor<float> *res) {
+  // trace_matmul_call(lhs_rank, lhs, rhs_rank, rhs, res_rank, res);
+  float alpha = 1.0;
+  float beta = 1.0;
+  auto m = lhs->rank[0];
+  auto k = lhs->rank[1];
+  auto n = rhs->rank[0];
+  // std::cout << "Using MKL implementation. [m(rows op(A)): " << m
+  //           << ", k(cols op(A)): " << k << ", n(cols op(B)  = cols C): " << n
+  //           << "]" << std::endl;
+  cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, m, n, k, alpha,
+              lhs->data, k, rhs->data, k, beta, res->data, n);
+}
+
+extern "C" void
+matmul_transpose_a_kernel_f32(int64_t lhs_rank, tensor<float> *lhs,
+                              int64_t rhs_rank, tensor<float> *rhs,
+                              int64_t res_rank, tensor<float> *res) {
+  // trace_matmul_call(lhs_rank, lhs, rhs_rank, rhs, res_rank, res);
+  std::cout << "[Matmul transpose a] Not tested MKL implementation." << std::endl;
+  float alpha = 1.0;
+  float beta = 1.0;
+  auto m = lhs->rank[1];
+  auto k = lhs->rank[0];
+  auto n = rhs->rank[1];
+  // std::cout << "Using MKL implementation. [m(rows op(A)): " << m
+  //           << ", k(cols op(A)): " << k << ", n(cols op(B)  = cols C): " << n
+  //           << "]" << std::endl;
+  cblas_sgemm(CblasRowMajor, CblasTrans, CblasNoTrans, m, n, k, alpha,
+              lhs->data, k, rhs->data, k, beta, res->data, n);
+}
+
 extern "C" void matmul_kernel_f64(int64_t lhs_rank, tensor<double> *lhs,
                                   int64_t rhs_rank, tensor<double> *rhs,
                                   int64_t res_rank, tensor<double> *res) {

--- a/lib/Runtime/Kernels.cpp
+++ b/lib/Runtime/Kernels.cpp
@@ -1,0 +1,85 @@
+#include <cstdint>
+#include <iostream>
+
+#include "mkl.h"
+
+template <typename T> struct tensor {
+  T *buffer;         // Allocated memory, used for deallocation only
+  T *data;           // Aligned data.
+  int64_t offset;    // Offset (in elems) to the first element
+  int64_t rank[2];   // Shape in elems
+  int64_t stride[2]; // Strides in elems
+
+  T &ref(int64_t i, int64_t j) {
+    return *(data + i * stride[0] + j * stride[1]);
+  }
+};
+
+namespace {
+template <typename T>
+void trace_matmul_call(int64_t lhs_rank, tensor<T> *lhs, int64_t rhs_rank,
+                       tensor<T> *rhs, int64_t res_rank, tensor<T> *res) {
+  std::cout << "test_matmul" << std::endl;
+  std::cout << "  lhs_rank=" << lhs_rank << std::endl
+            << "  rhs_rank=" << rhs_rank << std::endl
+            << "  res_rank=" << res_rank << std::endl;
+  std::cout << "  lhs={" << lhs->buffer << ", " << lhs->data << ", "
+            << lhs->offset << ", [" << lhs->rank[0] << ", " << lhs->rank[1]
+            << "], [" << lhs->stride[0] << ", " << lhs->stride[1] << "]}"
+            << std::endl;
+  std::cout << "  rhs={" << rhs->buffer << ", " << rhs->data << ", "
+            << rhs->offset << ", [" << rhs->rank[0] << ", " << rhs->rank[1]
+            << "], [" << rhs->stride[0] << ", " << rhs->stride[1] << "]}"
+            << std::endl;
+  std::cout << "  res={" << res->buffer << ", " << res->data << ", "
+            << res->offset << ", [" << res->rank[0] << ", " << res->rank[1]
+            << "], [" << res->stride[0] << ", " << res->stride[1] << "]}"
+            << std::endl;
+}
+
+template <typename T>
+void test_matmul(int64_t lhs_rank, tensor<T> *lhs, int64_t rhs_rank,
+                 tensor<T> *rhs, int64_t res_rank, tensor<T> *res) {
+  trace_matmul_call(lhs_rank, lhs, rhs_rank, rhs, res_rank, res);
+  std::cout << "Using naive implementation." << std::endl;
+  for (int64_t i = 0; i < lhs->rank[0]; ++i) {
+    for (int64_t j = 0; j < rhs->rank[1]; ++j) {
+      for (int64_t k = 0; k < rhs->rank[0]; ++k) {
+        res->ref(i, j) += lhs->ref(i, k) * rhs->ref(k, j);
+      }
+    }
+  }
+}
+} // namespace
+
+// extern "C" void test_matmul_f16(int64_t lhs_rank, tensor<_Float16> *lhs,
+//                                 int64_t rhs_rank, tensor<_Float16> *rhs,
+//                                 int64_t res_rank, tensor<_Float16> *res) {
+//   test_matmul(lhs_rank, lhs, rhs_rank, rhs, res_rank, res);
+// }
+
+extern "C" void matmul_kernel_f32(int64_t lhs_rank, tensor<float> *lhs,
+                                  int64_t rhs_rank, tensor<float> *rhs,
+                                  int64_t res_rank, tensor<float> *res) {
+  // trace_matmul_call(lhs_rank, lhs, rhs_rank, rhs, res_rank, res);
+  // std::cout << "Using MKL implementation." << std::endl;
+  float alpha = 1.0;
+  float beta = 1.0;
+  auto m = lhs->rank[0];
+  auto k = lhs->rank[1];
+  auto n = rhs->rank[1];
+  cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, m, n, k, alpha,
+              lhs->data, k, rhs->data, n, beta, res->data, n);
+}
+
+extern "C" void matmul_kernel_f64(int64_t lhs_rank, tensor<double> *lhs,
+                                  int64_t rhs_rank, tensor<double> *rhs,
+                                  int64_t res_rank, tensor<double> *res) {
+  double alpha = 1.0;
+  double beta = 1.0;
+  auto m = lhs->rank[0];
+  auto k = lhs->rank[1];
+  auto n = rhs->rank[1];
+  cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, m, n, k, alpha,
+              lhs->data, k, rhs->data, n, beta, res->data, n);
+}

--- a/projects/pt1/e2e_testing/main.py
+++ b/projects/pt1/e2e_testing/main.py
@@ -26,6 +26,7 @@ from torch_mlir_e2e_test.configs import (
 from torch_mlir_e2e_test.linalg_on_tensors_backends.refbackend import RefBackendLinalgOnTensorsBackend
 from torch_mlir_e2e_test.linalg_on_tensors_backends.cpuprotobackend import CpuProtoLinalgOnTensorsBackend
 from torch_mlir_e2e_test.linalg_on_tensors_backends.gpuprotobackend import GpuProtoLinalgOnTensorsBackend
+from torch_mlir_e2e_test.linalg_on_tensors_backends.xsmmprotobackend import XsmmProtoLinalgOnTensorsBackend
 from torch_mlir_e2e_test.tosa_backends.linalg_on_tensors import LinalgOnTensorsTosaBackend
 
 from .xfail_sets import (
@@ -45,7 +46,7 @@ from torch_mlir_e2e_test.test_suite import register_all_tests
 register_all_tests()
 
 def _get_argparse():
-    config_choices = ["native_torch", "torchscript", "linalg", "make_fx_tosa", "tosa", "lazy_tensor_core", "torchdynamo", "cpuproto", "gpuproto"]
+    config_choices = ["native_torch", "torchscript", "linalg", "make_fx_tosa", "tosa", "lazy_tensor_core", "torchdynamo", "cpuproto", "gpuproto", "xsmm"]
     parser = argparse.ArgumentParser(description="Run torchscript e2e tests.")
     parser.add_argument("-c", "--config",
         choices=config_choices,
@@ -154,6 +155,10 @@ def main():
         crashing_set = TORCHDYNAMO_CRASHING_SET
     elif args.config == "gpuproto":
         config = TorchDynamoTestConfig(GpuProtoLinalgOnTensorsBackend(opts), opts=opts)
+        xfail_set = TORCHDYNAMO_XFAIL_SET
+        crashing_set = TORCHDYNAMO_CRASHING_SET
+    elif args.config == "xsmm":
+        config = TorchDynamoTestConfig(XsmmProtoLinalgOnTensorsBackend(opts), opts=opts)
         xfail_set = TORCHDYNAMO_XFAIL_SET
         crashing_set = TORCHDYNAMO_CRASHING_SET
 

--- a/projects/pt1/e2e_testing/main.py
+++ b/projects/pt1/e2e_testing/main.py
@@ -61,6 +61,10 @@ Meaning of options:
     parser.add_argument("-f", "--filter", default=".*", help="""
 Regular expression specifying which tests to include in this run.
 """)
+    parser.add_argument("-l", "--list_tests",
+                        default=False,
+                        action="store_true",
+                        help="List all available tests and exit.")
     parser.add_argument("-v", "--verbose",
                         default=False,
                         action="store_true",
@@ -97,11 +101,15 @@ Available options:
                         default=False,
                         action="store_true",
                         help="Enable linalg ops replacement with runtime library kernel calls.")
+    parser.add_argument("--enable-timer",
+                        default=False,
+                        action="store_true",
+                        help="Enable debug timings collection.")
     return parser
 
 def main():
     args = _get_argparse().parse_args()
-    opts = TestOptions(dumps=args.dump, use_kernels=args.use_kernels)
+    opts = TestOptions(dumps=args.dump, use_kernels=args.use_kernels, debug_timer=args.enable_timer)
 
     all_test_unique_names = set(
         test.unique_name for test in GLOBAL_TEST_REGISTRY)
@@ -142,6 +150,12 @@ def main():
 
     do_not_attempt = set(args.crashing_tests_to_not_attempt_to_run_and_a_bug_is_filed or []).union(crashing_set)
     available_tests = [test for test in GLOBAL_TEST_REGISTRY if test.unique_name not in do_not_attempt]
+
+    if args.list_tests is True:
+        for test in available_tests:
+            print(test.unique_name)
+        sys.exit(0)
+
     if args.crashing_tests_to_not_attempt_to_run_and_a_bug_is_filed is not None:
         for arg in args.crashing_tests_to_not_attempt_to_run_and_a_bug_is_filed:
             if arg not in all_test_unique_names:

--- a/projects/pt1/e2e_testing/main.py
+++ b/projects/pt1/e2e_testing/main.py
@@ -24,6 +24,7 @@ from torch_mlir_e2e_test.configs import (
 )
 
 from torch_mlir_e2e_test.linalg_on_tensors_backends.refbackend import RefBackendLinalgOnTensorsBackend
+from torch_mlir_e2e_test.linalg_on_tensors_backends.cpuprotobackend import CpuProtoLinalgOnTensorsBackend
 from torch_mlir_e2e_test.tosa_backends.linalg_on_tensors import LinalgOnTensorsTosaBackend
 
 from .xfail_sets import (
@@ -43,7 +44,7 @@ from torch_mlir_e2e_test.test_suite import register_all_tests
 register_all_tests()
 
 def _get_argparse():
-    config_choices = ["native_torch", "torchscript", "linalg", "make_fx_tosa", "tosa", "lazy_tensor_core", "torchdynamo"]
+    config_choices = ["native_torch", "torchscript", "linalg", "make_fx_tosa", "tosa", "lazy_tensor_core", "torchdynamo", "cpuproto"]
     parser = argparse.ArgumentParser(description="Run torchscript e2e tests.")
     parser.add_argument("-c", "--config",
         choices=config_choices,
@@ -92,11 +93,15 @@ Available options:
 "linalg-mlir-lowering": dump after-pass results in Linalg to LLVM pipeline
 "obj": dump compiled code to object file
 """)
+    parser.add_argument("--use-kernels",
+                        default=False,
+                        action="store_true",
+                        help="Enable linalg ops replacement with runtime library kernel calls.")
     return parser
 
 def main():
     args = _get_argparse().parse_args()
-    opts = TestOptions(dumps=args.dump)
+    opts = TestOptions(dumps=args.dump, use_kernels=args.use_kernels)
 
     all_test_unique_names = set(
         test.unique_name for test in GLOBAL_TEST_REGISTRY)
@@ -128,6 +133,10 @@ def main():
         crashing_set = LTC_CRASHING_SET
     elif args.config == "torchdynamo":
         config = TorchDynamoTestConfig(RefBackendLinalgOnTensorsBackend(), opts=opts)
+        xfail_set = TORCHDYNAMO_XFAIL_SET
+        crashing_set = TORCHDYNAMO_CRASHING_SET
+    elif args.config == "cpuproto":
+        config = TorchDynamoTestConfig(CpuProtoLinalgOnTensorsBackend(opts), opts=opts)
         xfail_set = TORCHDYNAMO_XFAIL_SET
         crashing_set = TORCHDYNAMO_CRASHING_SET
 

--- a/projects/pt1/examples/mlp.py
+++ b/projects/pt1/examples/mlp.py
@@ -1,0 +1,40 @@
+import torch
+import torch_mlir
+from torch_mlir_e2e_test.framework import TraceItem
+from torch_mlir_e2e_test.configs.torchdynamo import TorchDynamoTestConfig
+from torch_mlir_e2e_test.linalg_on_tensors_backends.refbackend import (
+    RefBackendLinalgOnTensorsBackend,
+)
+
+
+class MLP(torch.nn.Module):
+    def __init__(self, input_dim, output_dim):
+        super().__init__()
+        self.flatten = torch.nn.Flatten()
+        self.linear1 = torch.nn.Linear(input_dim, input_dim // 2)
+        self.relu = torch.nn.ReLU()
+        self.linear2 = torch.nn.Linear(input_dim // 2, output_dim)
+
+    def forward(self, x):
+        x = self.flatten(x)
+        x = self.linear1(x)
+        x = self.relu(x)
+        x = self.linear2(x)
+        return x
+
+
+def model_factory():
+    return MLP(16, 2)
+
+
+torch.set_default_dtype(torch.float16)
+model = model_factory()
+test_input = torch.rand(2, 4, 4)
+
+ref_res = [TraceItem(symbol="mlp", inputs=[test_input], output=model(test_input))]
+
+config = TorchDynamoTestConfig(RefBackendLinalgOnTensorsBackend())
+exp_res = config.run(model, ref_res)
+
+print(ref_res[0].output)
+print(exp_res[0].output)

--- a/projects/pt1/python/torch_mlir/__init__.py
+++ b/projects/pt1/python/torch_mlir/__init__.py
@@ -268,7 +268,7 @@ def _canon_extra_library(extra_library):
     return extra_library_file_name
 
 
-def _lower_mlir_module(verbose, output_type, module):
+def _lower_mlir_module(verbose, output_type, module, ir_dump_file = None):
     if verbose:
         print("\n====================")
         print("Torch Backend IR")
@@ -280,7 +280,7 @@ def _lower_mlir_module(verbose, output_type, module):
     if output_type == OutputType.TOSA:
         run_pipeline_with_repro_report(
             module, "builtin.module(torch-backend-to-tosa-backend-pipeline)",
-            "Lowering Torch Backend IR -> TOSA Backend IR")
+            "Lowering Torch Backend IR -> TOSA Backend IR", ir_dump_file)
         if verbose:
             print("\n====================")
             print("TOSA Backend IR")
@@ -291,7 +291,7 @@ def _lower_mlir_module(verbose, output_type, module):
         run_pipeline_with_repro_report(
             module,
             "builtin.module(torch-backend-to-linalg-on-tensors-backend-pipeline)",
-            "Lowering Torch Backend IR -> Linalg-on-Tensors Backend IR")
+            "Lowering Torch Backend IR -> Linalg-on-Tensors Backend IR", ir_dump_file)
         if verbose:
             print("\n====================")
             print("LINALG Backend IR")
@@ -302,7 +302,7 @@ def _lower_mlir_module(verbose, output_type, module):
         run_pipeline_with_repro_report(
             module,
             "builtin.module(torch-backend-to-stablehlo-backend-pipeline)",
-            "Lowering Torch Backend IR -> StableHLO Backend IR")
+            "Lowering Torch Backend IR -> StableHLO Backend IR", ir_dump_file)
         if verbose:
             print("\n====================")
             print("StableHLO Backend IR")

--- a/projects/pt1/python/torch_mlir/compiler_utils.py
+++ b/projects/pt1/python/torch_mlir/compiler_utils.py
@@ -30,6 +30,8 @@ class StderrToFile:
         self._file_name = file
 
     def __enter__(self):
+        if os.path.exists(self._file_name):
+            os.remove(self._file_name)
         self._fd = os.open(self._file_name, os.O_WRONLY | os.O_CREAT)
         self._old_stderr_fd = os.dup(2)
         os.dup2(self._fd, 2)

--- a/projects/pt1/python/torch_mlir_e2e_test/configs/torchdynamo.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/configs/torchdynamo.py
@@ -62,6 +62,39 @@ def _returns_empty_tuple(fx_graph: torch.fx.GraphModule) -> bool:
     return True
 
 
+def transform(gm: torch.fx.GraphModule):
+
+    print("============transform============")
+    # Modify gm.graph
+    for node in gm.graph.nodes:
+        # Checks if we're calling a function (i.e:
+        # torch.add)
+        if node.op == 'call_function':
+            # The target attribute is the function
+            # that call_function calls.
+            # call_function[target=torch.ops.aten.add.Tensor](args = (%arg64_1, 1), kwargs = {})
+            if node.target == torch.ops.aten.add.Tensor:
+                if len(node.args) != 2 or node.kwargs != {}:
+                    print("skipping --- node: ", node, "args: ", node.args, " kwargs: ", node.kwargs)
+                elif not isinstance(node.args[1], torch.fx.node.Node):
+                    node.target = torch.ops.aten.add.Scalar
+                    print("node: ", node, "args: ", node.args, " kwargs: ", node.kwargs)
+                    print("argtypes: ", type(node.args[0]), type(node.args[1]))
+            if node.target == torch.ops.aten.mul.Tensor:
+                if len(node.args) != 2 or node.kwargs != {}:
+                    print("skipping --- node: ", node, "args: ", node.args, " kwargs: ", node.kwargs)
+                elif not isinstance(node.args[1], torch.fx.node.Node):
+                    node.target = torch.ops.aten.mul.Scalar
+                    print("node: ", node, "args: ", node.args)
+                # node.target = torch.mul
+
+    gm.graph.lint() # Does some checks to make sure the
+
+    # Recompile the forward() method of `gm` from its Graph
+    gm.recompile()
+    print("============transform============")
+
+
 def jit(
     model: torch.nn.Module,
     example_args: _example_args,
@@ -98,8 +131,16 @@ def jit(
         assert not _returns_empty_tuple(gm), "encountered graph that does not return anything"
 
         if opts.is_dump_enabled("fx-graph"):
+            with open(f"{model._get_name()}.{symbol}-fx-graph-before.py", "w") as f:
+                    print(gm.code, file=f)
+
+        transform(gm)
+
+        if opts.is_dump_enabled("fx-graph"):
             with open(f"{model._get_name()}.{symbol}-fx-graph.txt", "w") as f:
                 print(gm.graph, file=f)
+            with open(f"{model._get_name()}.{symbol}-fx-graph.py", "w") as f:
+                print(gm.code, file=f)
 
         nonlocal mlir_module
         *_, model_name, nth_graph = get_aot_compilation_context()
@@ -108,7 +149,6 @@ def jit(
         if opts.is_dump_enabled("torch-mlir"):
             with open(f"{model._get_name()}.{symbol}-torch.mlir", "w") as f:
                 print(mlir_module, file=f)
-
         return gm
 
     my_backend = aot_autograd(fw_compiler=my_aot_autograd_backend,

--- a/projects/pt1/python/torch_mlir_e2e_test/framework.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/framework.py
@@ -95,6 +95,17 @@ def clone_trace(trace: Trace) -> Trace:
 # this type.
 CompiledArtifact = TypeVar('CompiledArtifact')
 
+class TestOptions:
+    """Test run options."""
+
+    dump_choices = ["all", "fx-graph", "torch-mlir", "linalg-mlir", "llvm-mlir", "torch-mlir-lowering", "linalg-mlir-lowering", "obj"]
+
+    def __init__(self, dumps: List[str] = []):
+        self.dumps = {opt for opt in dumps}
+
+    def is_dump_enabled(self, dump: str):
+        return dump in self.dumps or "all" in self.dumps
+
 class TestConfig(abc.ABC):
     """The interface implemented by backends to run tests.
 

--- a/projects/pt1/python/torch_mlir_e2e_test/framework.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/framework.py
@@ -100,8 +100,9 @@ class TestOptions:
 
     dump_choices = ["all", "fx-graph", "torch-mlir", "linalg-mlir", "llvm-mlir", "torch-mlir-lowering", "linalg-mlir-lowering", "obj"]
 
-    def __init__(self, dumps: List[str] = []):
+    def __init__(self, *, dumps: List[str] = [], use_kernels=False):
         self.dumps = {opt for opt in dumps}
+        self.use_kernels = use_kernels
 
     def is_dump_enabled(self, dump: str):
         return dump in self.dumps or "all" in self.dumps

--- a/projects/pt1/python/torch_mlir_e2e_test/framework.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/framework.py
@@ -161,11 +161,12 @@ class TestOptions:
 
     dump_choices = ["all", "fx-graph", "torch-mlir", "linalg-mlir", "llvm-mlir", "torch-mlir-lowering", "linalg-mlir-lowering", "obj"]
 
-    def __init__(self, *, dumps: List[str] = [], use_kernels=False, debug_timer=False, use_gpu_runtime=False):
+    def __init__(self, *, dumps: List[str] = [], use_kernels=False, debug_timer=False, use_gpu_runtime=False, use_omp=True):
         self.dumps = {opt for opt in dumps}
         self.use_kernels = use_kernels
         self.debug_timer = debug_timer
         self.use_gpu_runtime = use_gpu_runtime
+        self.use_omp = use_omp
 
     def is_dump_enabled(self, dump: str):
         return dump in self.dumps or "all" in self.dumps

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
@@ -10,7 +10,7 @@ from torch_mlir.passmanager import *
 from torch_mlir.execution_engine import *
 from torch_mlir.runtime import *
 from torch_mlir.compiler_utils import run_pipeline_with_repro_report
-from torch_mlir_e2e_test.framework import TestOptions
+from torch_mlir_e2e_test.framework import TestOptions, DebugTimer
 
 from .abc import LinalgOnTensorsBackend
 from .refbackend import RefBackendInvoker
@@ -118,14 +118,15 @@ class CpuProtoLinalgOnTensorsBackend(LinalgOnTensorsBackend):
           An opaque, backend specific compiled artifact object that can be
           passed to `load`.
         """
-
-        run_pipeline_with_repro_report(
-            imported_module, _build_lowering_pipeline(self._opts),
-            "Lowering Linalg-on-Tensors IR to LLVM with RefBackend", ir_file)
+        with DebugTimer('CpuProtoLinalgOnTensorsBackend.compile()', logger=print if self._opts.debug_timer else None):
+            run_pipeline_with_repro_report(
+                imported_module, _build_lowering_pipeline(self._opts),
+                "Lowering Linalg-on-Tensors IR to LLVM with RefBackend", ir_file)
         return imported_module
 
     def load(self, module) -> RefBackendInvoker:
         """Loads a compiled artifact into the runtime."""
-
-        return RefBackendInvoker(module,
-                                 shared_libs=_collect_shared_libs(self._opts))
+        with DebugTimer('CpuProtoLinalgOnTensorsBackend.load()', logger=print if self._opts.debug_timer else None):
+            invoker = RefBackendInvoker(module,
+                                    shared_libs=_collect_shared_libs(self._opts))
+        return invoker

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
@@ -14,6 +14,7 @@ from torch_mlir_e2e_test.framework import TestOptions, DebugTimer
 
 from .abc import LinalgOnTensorsBackend
 from .refbackend import RefBackendInvoker
+from .utils import _collect_shared_libs
 
 __all__ = [
     "CpuProtoLinalgOnTensorsBackend",
@@ -82,21 +83,6 @@ def _build_lowering_pipeline(opts: TestOptions):
         "reconcile-unrealized-casts"
     ])
     return "builtin.module(" + ",".join(passes) + ")"
-
-
-def _find_shared_lib(name):
-    this_file_dir = os.path.dirname(os.path.abspath(__file__))
-    lib_file_path = f"{this_file_dir}/../../torch_mlir/_mlir_libs/{name}"
-    if not os.path.isfile(lib_file_path):
-        raise RuntimeError(f"Cannot find runtime library: {lib_file_path}")
-    return lib_file_path
-
-
-def _collect_shared_libs(opts: TestOptions):
-    shared_libs = []
-    if opts.use_kernels:
-        shared_libs.append(_find_shared_lib("libTorchMLIRKernels.so"))
-    return shared_libs
 
 
 class CpuProtoLinalgOnTensorsBackend(LinalgOnTensorsBackend):

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
@@ -128,5 +128,5 @@ class CpuProtoLinalgOnTensorsBackend(LinalgOnTensorsBackend):
         """Loads a compiled artifact into the runtime."""
         with DebugTimer('CpuProtoLinalgOnTensorsBackend.load()', logger=print if self._opts.debug_timer else None):
             invoker = RefBackendInvoker(module,
-                                    shared_libs=_collect_shared_libs(self._opts))
+                                    shared_libs=_collect_shared_libs(self._opts), logger=print if self._opts.debug_timer else None)
         return invoker

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
@@ -22,6 +22,7 @@ __all__ = [
 
 def _build_lowering_pipeline(opts: TestOptions):
     passes = [
+        "fuse-linalg-ops",
         "func.func(refback-generalize-tensor-pad)",
         # Apply some optimizations. It would be great if MLIR had more useful
         # optimizations that worked out of the box here.

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/cpuprotobackend.py
@@ -1,0 +1,131 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+import os
+
+from torch_mlir.ir import *
+from torch_mlir.passmanager import *
+from torch_mlir.execution_engine import *
+from torch_mlir.runtime import *
+from torch_mlir.compiler_utils import run_pipeline_with_repro_report
+from torch_mlir_e2e_test.framework import TestOptions
+
+from .abc import LinalgOnTensorsBackend
+from .refbackend import RefBackendInvoker
+
+__all__ = [
+    "CpuProtoLinalgOnTensorsBackend",
+]
+
+
+def _build_lowering_pipeline(opts: TestOptions):
+    passes = [
+        "func.func(refback-generalize-tensor-pad)",
+        # Apply some optimizations. It would be great if MLIR had more useful
+        # optimizations that worked out of the box here.
+        # Note: When measured, this doesn't seem to actually help that much
+        # for the linalg-on-tensors backend.
+        # This is likely because if things are naturally fusable we usually already
+        # emit things in that form from the high level (e.g. single linalg-generic).
+        # Other backends are likely to benefit more.
+        "func.func(linalg-fuse-elementwise-ops)",
+        "convert-shape-to-std",
+        # Bufferize.
+        "func.func(scf-bufferize)",
+        "func.func(tm-tensor-bufferize)",
+        "func.func(empty-tensor-to-alloc-tensor)",
+        "func.func(linalg-bufferize)",
+        "func-bufferize",
+        "arith-bufferize",
+        "refback-mlprogram-bufferize",
+        "func.func(tensor-bufferize)",
+        "func.func(finalizing-bufferize)",
+        "func.func(buffer-deallocation)",
+        # Munge to make it ExecutionEngine compatible.
+        # Specifically, we rewrite calling convention boundaries to be in terms
+        # of unranked memref, and we rewrite the return to actually be a
+        # callback that consumes the return (the final munged function always
+        # returns void at the C level -- we get the return value by providing the
+        # callback).
+        "refback-munge-calling-conventions"
+    ]
+    if opts.use_kernels:
+        # Introduce kernel calls for operations we want to execute using library
+        # kernels.
+        passes.append("convert-linalg-ops-to-kernel-calls")
+    passes.extend([
+        # Insert global variable and instruction sequence for getting the next
+        # global seed used in stateful rng.
+        # Lower to LLVM
+        "func.func(tm-tensor-to-loops)",
+        "func.func(refback-munge-memref-copy)",
+        "func.func(convert-linalg-to-loops)",
+        "func.func(lower-affine)",
+        "convert-scf-to-cf",
+        "func.func(refback-expand-ops-for-llvm)",
+        "func.func(arith-expand)",
+        "func.func(convert-math-to-llvm)",
+        # Handle some complex mlir::math ops (e.g. atan2)
+        "convert-math-to-libm",
+        "expand-strided-metadata",
+        "finalize-memref-to-llvm",
+        "lower-affine",
+        "convert-bufferization-to-memref",
+        "finalize-memref-to-llvm",
+        "func.func(convert-arith-to-llvm)",
+        "convert-func-to-llvm",
+        "convert-cf-to-llvm",
+        "convert-complex-to-llvm",
+        "reconcile-unrealized-casts"
+    ])
+    return "builtin.module(" + ",".join(passes) + ")"
+
+
+def _find_shared_lib(name):
+    this_file_dir = os.path.dirname(os.path.abspath(__file__))
+    lib_file_path = f"{this_file_dir}/../../torch_mlir/_mlir_libs/{name}"
+    if not os.path.isfile(lib_file_path):
+        raise RuntimeError(f"Cannot find runtime library: {lib_file_path}")
+    return lib_file_path
+
+
+def _collect_shared_libs(opts: TestOptions):
+    shared_libs = []
+    if opts.use_kernels:
+        shared_libs.append(_find_shared_lib("libTorchMLIRKernels.so"))
+    return shared_libs
+
+
+class CpuProtoLinalgOnTensorsBackend(LinalgOnTensorsBackend):
+    """Main entry-point for the reference backend."""
+    def __init__(self, opts: TestOptions = TestOptions()):
+        super().__init__()
+        self._opts = opts
+
+    def compile(self, imported_module: Module, ir_file: str = None):
+        """Compiles an imported module, with a flat list of functions.
+        The module is expected to be in linalg-on-tensors + scalar code form.
+        TODO: More clearly define the backend contract. Generally this will
+        extend to support globals, lists, and other stuff.
+
+        Args:
+          imported_module: The MLIR module consisting of funcs in the torch
+            dialect.
+          ir_file: If specified, use it as output file for MLIR passes dumps
+        Returns:
+          An opaque, backend specific compiled artifact object that can be
+          passed to `load`.
+        """
+
+        run_pipeline_with_repro_report(
+            imported_module, _build_lowering_pipeline(self._opts),
+            "Lowering Linalg-on-Tensors IR to LLVM with RefBackend", ir_file)
+        return imported_module
+
+    def load(self, module) -> RefBackendInvoker:
+        """Loads a compiled artifact into the runtime."""
+
+        return RefBackendInvoker(module,
+                                 shared_libs=_collect_shared_libs(self._opts))

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/gpuprotobackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/gpuprotobackend.py
@@ -1,0 +1,143 @@
+
+from torch_mlir.ir import *
+from torch_mlir.passmanager import *
+from torch_mlir.execution_engine import *
+from torch_mlir.runtime import *
+
+from torch_mlir.compiler_utils import run_pipeline_with_repro_report
+from torch_mlir_e2e_test.framework import TestOptions, DebugTimer
+
+from .abc import LinalgOnTensorsBackend
+from .refbackend import RefBackendInvoker
+from .utils import _collect_shared_libs
+
+__all__ = [
+    "GpuProtoLinalgOnTensorsBackend",
+]
+
+LOWERING_PIPELINE = "builtin.module(" + ",".join([
+    "func.func(refback-generalize-tensor-pad)",
+    # Apply some optimizations. It would be great if MLIR had more useful
+    # optimizations that worked out of the box here.
+    # Note: When measured, this doesn't seem to actually help that much
+    # for the linalg-on-tensors backend.
+    # This is likely because if things are naturally fusable we usually already
+    # emit things in that form from the high level (e.g. single linalg-generic).
+    # Other backends are likely to benefit more.
+    "func.func(linalg-fuse-elementwise-ops)",
+    "convert-shape-to-std",
+    
+    # # Bufferize (old).
+    "func.func(scf-bufferize)",
+    "func.func(tm-tensor-bufferize)",
+    "func.func(empty-tensor-to-alloc-tensor)",
+    "func.func(linalg-bufferize)",
+    "func-bufferize",
+    "arith-bufferize",
+    "refback-mlprogram-bufferize",
+    "func.func(tensor-bufferize)",
+    "func.func(finalizing-bufferize)",
+    "func.func(buffer-deallocation)",
+
+    # Bufferize (new)
+    # "arith-bufferize",
+    # "func.func(tm-tensor-bufferize)",
+    # "func.func(empty-tensor-to-alloc-tensor",
+    #     "scf-bufferize",
+    #     "shape-bufferize",
+    #     "linalg-bufferize",
+    #     "bufferization-bufferize",
+    #     "tensor-bufferize)",
+    # "func-bufferize",
+    # "refback-mlprogram-bufferize", 
+
+    
+    # Insert global variable and instruction sequence for getting the next
+    # global seed used in stateful rng.
+    # Lower to LLVM
+    "func.func(tm-tensor-to-loops)",
+    "func.func(refback-munge-memref-copy)",
+
+    # Lower to gpu
+    # "func.func(finalizing-bufferize",
+    # "func.func(",
+    #       "convert-linalg-to-parallel-loops",
+    #       "gpu-map-parallel-loops",
+    #       "convert-parallel-loops-to-gpu)",
+    "func.func(convert-linalg-to-parallel-loops)",
+    "func.func(gpu-map-parallel-loops)",
+    "func.func(convert-parallel-loops-to-gpu)",
+    "func.func(insert-gpu-allocs{client-api=opencl})",
+    "canonicalize",
+    "normalize-memrefs",
+    "func.func(lower-affine)",
+    "gpu-kernel-outlining",
+    "canonicalize",
+    "cse",
+    "set-spirv-capabilities{client-api=opencl}",
+    "gpu.module(set-spirv-abi-attrs{client-api=opencl})",
+    "canonicalize",
+    "fold-memref-alias-ops",
+    "imex-convert-gpu-to-spirv{enable-genisa-intrinsic}",
+    "spirv.module(spirv-lower-abi-attrs",
+             "spirv-update-vce)",
+    "func.func(llvm-request-c-wrappers)",
+    "serialize-spirv",
+    "convert-gpu-to-gpux",
+
+    # Munge to make it ExecutionEngine compatible.
+    # Specifically, we rewrite calling convention boundaries to be in terms
+    # of unranked memref, and we rewrite the return to actually be a
+    # callback that consumes the return (the final munged function always
+    # returns void at the C level -- we get the return value by providing the
+    # callback).
+    "refback-munge-calling-conventions",
+
+    "convert-vector-to-scf",
+    "convert-vector-to-scf",
+    "convert-vector-to-llvm",
+    "convert-index-to-llvm",
+    "convert-arith-to-llvm",
+    "convert-func-to-llvm",
+    "convert-math-to-llvm",
+    "convert-gpux-to-llvm",
+    "convert-index-to-llvm",
+    "expand-strided-metadata",
+    "lower-affine",
+    "finalize-memref-to-llvm",
+    "reconcile-unrealized-casts",
+]) + ")"
+
+
+class GpuProtoLinalgOnTensorsBackend(LinalgOnTensorsBackend):
+    """Main entry-point for the reference backend."""
+    def __init__(self, opts: TestOptions = TestOptions()):
+        super().__init__()
+        self._opts = opts
+    
+    def compile(self, imported_module: Module, ir_file: str = None):
+        """Compiles an imported module, with a flat list of functions.
+        The module is expected to be in linalg-on-tensors + scalar code form.
+        TODO: More clearly define the backend contract. Generally this will
+        extend to support globals, lists, and other stuff.
+
+        Args:
+          imported_module: The MLIR module consisting of funcs in the torch
+            dialect.
+          ir_file: If specified, use it as output file for MLIR passes dumps
+        Returns:
+          An opaque, backend specific compiled artifact object that can be
+          passed to `load`.
+        """
+        with DebugTimer('GpuProtoLinalgOnTensorsBackend.compile()', logger=print if self._opts.debug_timer else None):
+            run_pipeline_with_repro_report(
+                imported_module, LOWERING_PIPELINE,
+                "Lowering Linalg-on-Tensors IR to LLVM with RefBackend", ir_file)
+        return imported_module
+
+    def load(self, module) -> RefBackendInvoker:
+        """Loads a compiled artifact into the runtime."""
+        with DebugTimer('GpuProtoLinalgOnTensorsBackend.load()', logger=print if self._opts.debug_timer else None):
+            invoker = RefBackendInvoker(module,
+                                    shared_libs=_collect_shared_libs(self._opts))
+        return invoker

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -182,7 +182,7 @@ class RefBackendLinalgOnTensorsBackend(LinalgOnTensorsBackend):
     def __init__(self):
         super().__init__()
 
-    def compile(self, imported_module: Module):
+    def compile(self, imported_module: Module, ir_file: str = None):
         """Compiles an imported module, with a flat list of functions.
         The module is expected to be in linalg-on-tensors + scalar code form.
         TODO: More clearly define the backend contract. Generally this will
@@ -198,7 +198,7 @@ class RefBackendLinalgOnTensorsBackend(LinalgOnTensorsBackend):
 
         run_pipeline_with_repro_report(
             imported_module, LOWERING_PIPELINE,
-            "Lowering Linalg-on-Tensors IR to LLVM with RefBackend")
+            "Lowering Linalg-on-Tensors IR to LLVM with RefBackend", ir_file)
         return imported_module
 
     def load(self, module) -> RefBackendInvoker:

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -80,8 +80,8 @@ def get_ctype_func(func_name):
 
 class RefBackendInvoker:
 
-    def __init__(self, module):
-        self.ee = ExecutionEngine(module)
+    def __init__(self, module, shared_libs=None):
+        self.ee = ExecutionEngine(module, shared_libs=shared_libs)
         self.result = None
 
         return_funcs = get_return_funcs(module)

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/utils.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/utils.py
@@ -1,0 +1,20 @@
+import os
+
+from torch_mlir_e2e_test.framework import TestOptions
+
+def _find_shared_lib(name):
+    this_file_dir = os.path.dirname(os.path.abspath(__file__))
+    lib_file_path = f"{this_file_dir}/../../torch_mlir/_mlir_libs/{name}"
+    if not os.path.isfile(lib_file_path):
+        raise RuntimeError(f"Cannot find runtime library: {lib_file_path}")
+    return lib_file_path
+
+
+def _collect_shared_libs(opts: TestOptions):
+    shared_libs = []
+    if opts.use_kernels:
+        shared_libs.append(_find_shared_lib("libTorchMLIRKernels.so"))
+    if opts.use_gpu_runtime:
+        shared_libs.append(_find_shared_lib("liblevel-zero-runtime.so"))
+    return shared_libs
+

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/utils.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/utils.py
@@ -4,17 +4,27 @@ from torch_mlir_e2e_test.framework import TestOptions
 
 def _find_shared_lib(name):
     this_file_dir = os.path.dirname(os.path.abspath(__file__))
-    lib_file_path = f"{this_file_dir}/../../torch_mlir/_mlir_libs/{name}"
-    if not os.path.isfile(lib_file_path):
-        raise RuntimeError(f"Cannot find runtime library: {lib_file_path}")
-    return lib_file_path
+
+    search_dirs = [f"{this_file_dir}/../../torch_mlir/_mlir_libs",
+                   f"{this_file_dir}/../../../../../../lib",
+                   "/usr/lib"]
+    if os.environ.get("CONDA_PREFIX", None):
+        search_dirs.append(os.environ.get("CONDA_PREFIX") + "/lib")
+    for dir in search_dirs:
+        lib_file_path = f"{dir}/{name}"
+        if os.path.isfile(lib_file_path):
+            return lib_file_path
+
+    raise RuntimeError(f"Cannot find runtime library {name}. Searched paths: {search_dirs}")
 
 
-def _collect_shared_libs(opts: TestOptions):
-    shared_libs = []
+def _collect_shared_libs(opts: TestOptions, libs = []):
+    shared_libs = [_find_shared_lib(lib) for lib in libs]
     if opts.use_kernels:
         shared_libs.append(_find_shared_lib("libTorchMLIRKernels.so"))
     if opts.use_gpu_runtime:
         shared_libs.append(_find_shared_lib("liblevel-zero-runtime.so"))
+    if opts.use_omp:
+        shared_libs.append(_find_shared_lib("libiomp5.so"))
     return shared_libs
 

--- a/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/xsmmprotobackend.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/linalg_on_tensors_backends/xsmmprotobackend.py
@@ -1,0 +1,96 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+import os
+
+from torch_mlir.ir import *
+from torch_mlir.passmanager import *
+from torch_mlir.execution_engine import *
+from torch_mlir.runtime import *
+from torch_mlir.compiler_utils import run_pipeline_with_repro_report
+from torch_mlir_e2e_test.framework import TestOptions, DebugTimer
+
+from .abc import LinalgOnTensorsBackend
+from .refbackend import RefBackendInvoker
+from .utils import _collect_shared_libs
+
+__all__ = [
+    "CpuProtoLinalgOnTensorsBackend",
+]
+
+
+def _build_lowering_pipeline(opts: TestOptions):
+    passes = [
+        "linalg-generalize-named-ops",
+        "default-tpp-passes",
+        "refback-munge-calling-conventions",
+        "finalize-memref-to-llvm",
+        "expand-strided-metadata",
+        "convert-tensor-to-linalg",
+        "func.func(convert-linalg-to-loops)",
+    ]
+    if opts.use_omp:
+        passes.append("convert-scf-to-openmp")
+    passes.extend([
+        "convert-vector-to-scf",
+        "arith-expand",
+        "lower-affine",
+        "convert-vector-to-llvm",
+        "finalize-memref-to-llvm",
+        "convert-scf-to-cf"])
+    if opts.use_omp:
+        passes.append("convert-openmp-to-llvm")
+    passes.extend([
+        "convert-math-to-llvm",
+        #"func.func(gpu-async-region)",
+        #"gpu-to-llvm",
+        #"gpu-module-to-binary{format=fatbin}",
+        #"async-to-async-runtime",
+        #"async-runtime-ref-counting",
+        #"convert-async-to-llvm",
+        "convert-func-to-llvm",
+        "func.func(convert-arith-to-llvm)",
+        "func.func(canonicalize)",
+        "func.func(cse)",
+        "reconcile-unrealized-casts",
+        #"convert-gpu-launch-to-vulkan-launch",
+        "symbol-dce",
+    ])
+    return "builtin.module(" + ",".join(passes) + ")"
+
+
+class XsmmProtoLinalgOnTensorsBackend(LinalgOnTensorsBackend):
+    """Main entry-point for the reference backend."""
+    def __init__(self, opts: TestOptions = TestOptions()):
+        super().__init__()
+        self._opts = opts
+
+    def compile(self, imported_module: Module, ir_file: str = None):
+        """Compiles an imported module, with a flat list of functions.
+        The module is expected to be in linalg-on-tensors + scalar code form.
+        TODO: More clearly define the backend contract. Generally this will
+        extend to support globals, lists, and other stuff.
+
+        Args:
+          imported_module: The MLIR module consisting of funcs in the torch
+            dialect.
+          ir_file: If specified, use it as output file for MLIR passes dumps
+        Returns:
+          An opaque, backend specific compiled artifact object that can be
+          passed to `load`.
+        """
+        with DebugTimer('XsmmProtoLinalgOnTensorsBackend.compile()', logger=print if self._opts.debug_timer else None):
+            run_pipeline_with_repro_report(
+                imported_module, _build_lowering_pipeline(self._opts),
+                "Lowering Linalg-on-Tensors IR to LLVM with XsmmBackend", ir_file)
+        return imported_module
+
+    def load(self, module) -> RefBackendInvoker:
+        """Loads a compiled artifact into the runtime."""
+        with DebugTimer('XsmmProtoLinalgOnTensorsBackend.load()', logger=print if self._opts.debug_timer else None):
+            invoker = RefBackendInvoker(module,
+                                        shared_libs=_collect_shared_libs(self._opts, ["libtpp_xsmm_runner_utils.so"]),
+                                        logger=print if self._opts.debug_timer else None)
+        return invoker

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/mlp.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/mlp.py
@@ -99,3 +99,44 @@ class BatchMlpLayerModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: BatchMlpLayerModule())
 def BatchMlpLayerModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(7, 5, 3))
+
+
+class MLP(torch.nn.Module):
+    def __init__(self, input_dim, output_dim):
+        super().__init__()
+        self.flatten = torch.nn.Flatten()
+        self.linear1 = torch.nn.Linear(input_dim, input_dim // 2)
+        # self.relu = torch.nn.ReLU()
+        # self.linear2 = torch.nn.Linear(input_dim // 2, output_dim)
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        x = self.flatten(x)
+        x = self.linear1(x)
+        # x = self.relu(x)
+        # x = self.linear2(x)
+        return x
+
+model = MLP(128 * 128, 0)
+
+def model_factory():
+    return model
+
+
+test_input = torch.rand(1, 128, 128)
+w = model.linear1.weight.detach().numpy()
+b = model.linear1.bias.detach().numpy()
+print("in shape: ", test_input.shape)
+print(" w shape: ", w.shape)
+print(" b shape: ", b.shape)
+
+
+@register_test_case(module_factory=model_factory)
+def MLP_basic(module, tu: TestUtils):
+    out = module.forward(test_input)
+    print("[test body] out shape: ", out.size())
+

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/mlp.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/mlp.py
@@ -6,20 +6,35 @@
 import torch
 import torch.nn as nn
 
-from torch_mlir_e2e_test.framework import TestUtils
+from torch_mlir_e2e_test.framework import TestUtils, DebugTimer
 from torch_mlir_e2e_test.registry import register_test_case
 from torch_mlir_e2e_test.annotations import annotate_args, export
 
 # ==============================================================================
 
+class VectorAdd(torch.nn.Module):
+    @export
+    @annotate_args([None, ([2,2], torch.float32)])
+    def forward(self, x):
+        return torch.add(x, x)
+
+@register_test_case(module_factory=lambda: VectorAdd())
+def VectorAdd_basic(module, tu: TestUtils):
+    x = tu.rand(2)
+    print('passing ', x)
+    result = module.forward(x)
+    print(result)
+
 # Multi-layer perceptron (MLP) models.
 
+in_features = 3
+out_features = 5
 class Mlp1LayerModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
         # Reset seed to make model deterministic.
         torch.manual_seed(0)
-        self.fc0 = nn.Linear(3, 5)
+        self.fc0 = nn.Linear(in_features, out_features)
         self.tanh0 = nn.Tanh()
     @export
     @annotate_args([
@@ -31,7 +46,8 @@ class Mlp1LayerModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: Mlp1LayerModule())
 def Mlp1LayerModule_basic(module, tu: TestUtils):
-    module.forward(tu.rand(5, 3))
+    with DebugTimer("Mlp1LayerModule.forward()"):
+        module.forward(tu.rand(out_features, in_features))
 
 class Mlp2LayerModule(torch.nn.Module):
     def __init__(self):

--- a/projects/pt1/tools/collect.py
+++ b/projects/pt1/tools/collect.py
@@ -1,0 +1,39 @@
+import os
+import argparse
+
+def process(filename):
+    result = {}
+    with open(filename, 'r') as f:
+        data = f.readlines()
+        for line in data:
+            if 'elapsed' in line:
+                tmp = line.strip().split()
+                print(tmp[0].strip(':'), tmp[-2])
+                result[tmp[0].strip(':')] = tmp[-2]
+        result['size'] = filename.split('_')[0].strip('./')
+    return result
+
+def collect(path, result):
+    collection = []
+    for file in os.listdir(path):
+        if file.endswith('.log'):
+            print(os.path.join(path, file))
+            res = process(os.path.join(path, file))
+            collection.append(res)
+
+    with open(result, 'w') as f:
+        header = sorted(collection[0].keys())
+        f.write(",".join(header))
+        for item in collection:
+            values = []
+            for h in header:
+                values.append(item[h])
+            f.write("\n")
+            f.write(",".join(values))
+    
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Script for parsing debug timer dumps to convert it to a csv format.")
+    parser.add_argument('path', type=str, help="Provide a path to log files location.")
+    parser.add_argument('-o', '--output', default="result.csv", help="Resulting output filename.")
+    args = parser.parse_args()
+    collect(args.path, args.output)

--- a/tools/torch-mlir-opt/CMakeLists.txt
+++ b/tools/torch-mlir-opt/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 target_link_libraries(torch-mlir-opt PRIVATE
   MLIROptLib
   MLIRTransforms
+  IMEXTransforms
   TorchMLIRInitAll
   TorchMLIRTorchDialect
   TorchMLIRTorchPasses

--- a/utils/build-with-imex.sh
+++ b/utils/build-with-imex.sh
@@ -10,7 +10,7 @@ echo "Using project dir: ${project_dir}"
 git submodule foreach --recursive git checkout .
 
 pushd externals/mlir-extensions
-git checkout tags/v0.3
+git reset --hard
 git apply ${project_dir}/utils/public-deps.patch
 git apply ${project_dir}/utils/level-zero-runtime-log.patch
 popd
@@ -21,21 +21,22 @@ git apply ${project_dir}/externals/mlir-extensions/build_tools/patches/*
 git apply ${project_dir}/utils/llvm-error-msg.patch
 popd
 
+pushd externals/stablehlo
+git reset --hard
+git apply ${project_dir}/utils/token-name.patch
+popd
 
 cmake -GNinja -Bbuild \
     -DCMAKE_BUILD_TYPE=Release \
     -DPython3_FIND_VIRTUALENV=ONLY \
     -DLLVM_ENABLE_PROJECTS=mlir \
-    -DLLVM_EXTERNAL_PROJECTS="torch-mlir;Imex" \
+    -DLLVM_EXTERNAL_PROJECTS="torch-mlir;Imex;tpp-mlir" \
     -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR="$PWD" \
     -DLLVM_EXTERNAL_IMEX_SOURCE_DIR="$PWD/externals/mlir-extensions" \
+    -DLLVM_EXTERNAL_TPP_MLIR_SOURCE_DIR="$PWD/externals/tpp-mlir" \
     -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
     -DIMEX_ENABLE_L0_RUNTIME=ON \
     -DLLVM_TARGETS_TO_BUILD=host \
     externals/llvm-project/llvm
 
 cmake --build build
-
-# a dirty hack for library search
-cp build/lib/liblevel-zero-runtime.so* build/tools/torch-mlir/python_packages/torch_mlir/torch_mlir/_mlir_libs/
-

--- a/utils/build-with-imex.sh
+++ b/utils/build-with-imex.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -ex
+cd $(dirname "$0")/../
+
+project_dir=$PWD
+echo "Using project dir: ${project_dir}"
+
+# assuming git submodule update --init was done and all the code is present
+git submodule foreach --recursive git checkout .
+
+pushd externals/mlir-extensions
+git checkout tags/v0.3
+git apply ${project_dir}/utils/public-deps.patch
+git apply ${project_dir}/utils/level-zero-runtime-log.patch
+popd
+
+pushd externals/llvm-project
+git checkout `cat ${project_dir}/externals/mlir-extensions/build_tools/llvm_version.txt`
+git apply ${project_dir}/externals/mlir-extensions/build_tools/patches/*
+git apply ${project_dir}/utils/llvm-error-msg.patch
+popd
+
+
+cmake -GNinja -Bbuild \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DPython3_FIND_VIRTUALENV=ONLY \
+    -DLLVM_ENABLE_PROJECTS=mlir \
+    -DLLVM_EXTERNAL_PROJECTS="torch-mlir;Imex" \
+    -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR="$PWD" \
+    -DLLVM_EXTERNAL_IMEX_SOURCE_DIR="$PWD/externals/mlir-extensions" \
+    -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+    -DIMEX_ENABLE_L0_RUNTIME=ON \
+    -DLLVM_TARGETS_TO_BUILD=host \
+    externals/llvm-project/llvm
+
+cmake --build build
+
+# a dirty hack for library search
+cp build/lib/liblevel-zero-runtime.so* build/tools/torch-mlir/python_packages/torch_mlir/torch_mlir/_mlir_libs/
+

--- a/utils/level-zero-runtime-log.patch
+++ b/utils/level-zero-runtime-log.patch
@@ -44,7 +44,7 @@ index ccf2258..edf807e 100644
    desc.inputSize = dataSize;
    desc.pBuildFlags = build_flags;
    CHECK_ZE_RESULT(zeModuleCreate(gpuL0Queue->zeContext_, gpuL0Queue->zeDevice_,
-                                  &desc, &zeModule, nullptr));
+                                  &desc, &zeModule, buildlog));
 +  size_t logSize = 0;
 +  CHECK_ZE_RESULT(zeModuleBuildLogGetString(buildlog, &logSize, nullptr));
 +  std::string strLog(logSize, ' ');

--- a/utils/level-zero-runtime-log.patch
+++ b/utils/level-zero-runtime-log.patch
@@ -44,7 +44,7 @@ index ccf2258..edf807e 100644
    desc.inputSize = dataSize;
    desc.pBuildFlags = build_flags;
    CHECK_ZE_RESULT(zeModuleCreate(gpuL0Queue->zeContext_, gpuL0Queue->zeDevice_,
-                                  &desc, &zeModule, buildlog));
+                                  &desc, &zeModule, nullptr));
 +  size_t logSize = 0;
 +  CHECK_ZE_RESULT(zeModuleBuildLogGetString(buildlog, &logSize, nullptr));
 +  std::string strLog(logSize, ' ');

--- a/utils/level-zero-runtime-log.patch
+++ b/utils/level-zero-runtime-log.patch
@@ -1,0 +1,58 @@
+diff --git a/lib/ExecutionEngine/LEVELZERORUNTIME/LevelZeroRuntimeWrappers.cpp b/lib/ExecutionEngine/LEVELZERORUNTIME/LevelZeroRuntimeWrappers.cpp
+index ccf2258..edf807e 100644
+--- a/lib/ExecutionEngine/LEVELZERORUNTIME/LevelZeroRuntimeWrappers.cpp
++++ b/lib/ExecutionEngine/LEVELZERORUNTIME/LevelZeroRuntimeWrappers.cpp
+@@ -27,6 +27,8 @@
+ #include <tuple>
+ #include <vector>
+ 
++#include <iostream>
++
+ #include <level_zero/ze_api.h>
+ 
+ #ifdef _WIN32
+@@ -382,6 +384,7 @@ static ze_module_handle_t loadModule(GPUL0QUEUE *queue, const void *data,
+   auto it = moduleCache.find((const void *)data);
+   // Check the map if the module is present/cached.
+   if (it != moduleCache.end()) {
++    assert(false && "Module is cached");
+     return it->second.module;
+   }
+   ze_module_desc_t desc = {};
+@@ -394,13 +397,36 @@ static ze_module_handle_t loadModule(GPUL0QUEUE *queue, const void *data,
+         "-DPASTokenReduction -Xfinalizer -SWSBDepReduction -Xfinalizer "
+         "'-printregusage -enableBCR' ";
+   }
++  if (getenv("IMEX_ENABLE_VC_PATH")) {
++    build_flags = "-vc-codegen";
++  }
++
++  if (getenv("IMEX_MIMIC_OCLOC")) {
++    build_flags = "-ze-intel-has-buffer-offset-arg "
++                  "-cl-intel-greater-than-4GB-buffer-required "
++                  "-cl-store-cache-default=2 -cl-load-cache-default=4";
++  }
+ 
++  std::cerr << "L0 module build flags: "
++            << (build_flags ? build_flags : "empty") << std::endl;
++
++  ze_module_build_log_handle_t buildlog = nullptr;
++
++  desc.stype = ZE_STRUCTURE_TYPE_MODULE_DESC;
+   desc.format = ZE_MODULE_FORMAT_IL_SPIRV;
+   desc.pInputModule = static_cast<const uint8_t *>(data);
+   desc.inputSize = dataSize;
+   desc.pBuildFlags = build_flags;
+   CHECK_ZE_RESULT(zeModuleCreate(gpuL0Queue->zeContext_, gpuL0Queue->zeDevice_,
+                                  &desc, &zeModule, nullptr));
++  size_t logSize = 0;
++  CHECK_ZE_RESULT(zeModuleBuildLogGetString(buildlog, &logSize, nullptr));
++  std::string strLog(logSize, ' ');
++  CHECK_ZE_RESULT(zeModuleBuildLogGetString(buildlog, &logSize, strLog.data()));
++  if (logSize > 0) {
++    std::cerr << "L0 Module build log:\n" << strLog << std::endl;
++  }
++
+   std::lock_guard<std::mutex> entryLock(mutexLock);
+   moduleCache[(const void *)data].module = zeModule;
+   return zeModule;

--- a/utils/llvm-error-msg.patch
+++ b/utils/llvm-error-msg.patch
@@ -1,0 +1,27 @@
+diff --git a/mlir/lib/Bindings/Python/IRModule.h b/mlir/lib/Bindings/Python/IRModule.h
+index c5412e735ddd..672b5b65885c 100644
+--- a/mlir/lib/Bindings/Python/IRModule.h
++++ b/mlir/lib/Bindings/Python/IRModule.h
+@@ -9,6 +9,7 @@
+ #ifndef MLIR_BINDINGS_PYTHON_IRMODULES_H
+ #define MLIR_BINDINGS_PYTHON_IRMODULES_H
+ 
++#include <iostream>
+ #include <optional>
+ #include <utility>
+ #include <vector>
+@@ -407,6 +408,14 @@ struct PyMlirContext::ErrorCapture {
+                       /*deleteUserData=*/nullptr)) {}
+   ~ErrorCapture() {
+     mlirContextDetachDiagnosticHandler(ctx->get(), handlerID);
++    if (!errors.empty()) {
++      std::cerr << "Found " << errors.size() << " unhandled errors."
++                << std::endl;
++      for (auto &e : errors) {
++        std::cerr << e.message << std::endl;
++      }
++      std::cerr << "End of unhandled error list" << std::endl;
++    }
+     assert(errors.empty() && "unhandled captured errors");
+   }
+

--- a/utils/public-deps.patch
+++ b/utils/public-deps.patch
@@ -1,0 +1,47 @@
+commit 5ad00f8c30c14adaa7c2b908c20503c4f9825da6
+Author: Petr Kurapov <petr.a.kurapov@intel.com>
+Date:   Fri Dec 1 03:40:26 2023 -0700
+
+    Fix public dependencies propagation
+
+diff --git a/lib/Conversion/GPUToSPIRV/CMakeLists.txt b/lib/Conversion/GPUToSPIRV/CMakeLists.txt
+index 4fa56b2..35f2be9 100644
+--- a/lib/Conversion/GPUToSPIRV/CMakeLists.txt
++++ b/lib/Conversion/GPUToSPIRV/CMakeLists.txt
+@@ -18,4 +18,9 @@ add_mlir_conversion_library(IMEXGPUToSPIRV
+   MLIRSPIRVConversion
+   MLIRSupport
+   MLIRTransforms
++
++  MLIRGPUToSPIRV
++  MLIRControlFlowToSPIRV
++  MLIRMathToSPIRV
++
+   )
+diff --git a/lib/Conversion/GPUXToLLVM/CMakeLists.txt b/lib/Conversion/GPUXToLLVM/CMakeLists.txt
+index 56515be..c9ea54f 100644
+--- a/lib/Conversion/GPUXToLLVM/CMakeLists.txt
++++ b/lib/Conversion/GPUXToLLVM/CMakeLists.txt
+@@ -14,4 +14,8 @@ add_mlir_conversion_library(IMEXGPUXToLLVM
+   MLIRSCFToSPIRV
+   MLIRSupport
+   MLIRTransforms
++
++  MLIRMemRefToLLVM
++  MLIRAsyncToLLVM
++  MLIRGPUToGPURuntimeTransforms
+   )
+diff --git a/lib/Transforms/CMakeLists.txt b/lib/Transforms/CMakeLists.txt
+index 6b3bf59..34a62bc 100644
+--- a/lib/Transforms/CMakeLists.txt
++++ b/lib/Transforms/CMakeLists.txt
+@@ -19,6 +19,9 @@ add_mlir_library(IMEXTransforms
+   MLIRSupport
+   MLIRTransformUtils
+ 
++  MLIRGPUTransforms
++  MLIRSPIRVSerialization
++
+   DEPENDS
+   IMEXTransformsPassIncGen
+ )

--- a/utils/token-name.patch
+++ b/utils/token-name.patch
@@ -1,0 +1,12 @@
+diff --git a/stablehlo/dialect/StablehloOps.h b/stablehlo/dialect/StablehloOps.h
+index 76064150..2dd0aba5 100644
+--- a/stablehlo/dialect/StablehloOps.h
++++ b/stablehlo/dialect/StablehloOps.h
+@@ -75,6 +75,7 @@ class StablehloDialect : public Dialect {
+ class TokenType : public Type::TypeBase<TokenType, Type, TypeStorage> {
+  public:
+   using Base::Base;
++  static constexpr auto name = "stablehlo.token";
+ };
+ 
+ // Verifies the source target pairs attached to collective permute.


### PR DESCRIPTION
Replace `torch.ops.aten.add.Tensor` with `torch.ops.aten.add.Scalar`, as `add.Tensor` used to add Tensor to int/float. It breaks due to semantic of add.Tensor - args should be both Tensors. It's WA, that uses add.Scalar op with correct semantics. It also confirmed with xfail setup:
```
    # START tests failing due to: 'torch.aten.mul.Tensor' op operand #1 must be Any Torch tensor type, but got '!torch.float'
    "AddCDivModule_basic",
    "ElementwiseMulScalarModule_basic",
    "ElementwiseMulScalarModule_float",
    "NativeGroupNormBackwardModule_basic",
    "UpSampleNearest2dDynamicSize_basic",
    "UpSampleNearest2dStaticFactor_basic",
    "UpSampleNearest2dStaticSize_basic",
    "UpSampleNearest2d_basic",
    # END tests failing due to: 'torch.aten.mul.Tensor' op operand #1 must be Any Torch tensor type, but got '!torch.float'

    # START tests failing due to: 'torch.aten.add.Tensor' op operand #1 must be Any Torch tensor type, but got '!torch.float'
    "BatchNorm1DModule_basic",
    "BatchNorm1DWith2DInputModule_basic",
    "BatchNorm2DModule_basic",
    "BatchNorm3DModule_basic",
    "BatchNorm1DStaticShapeModule_basic",
    "ElementwiseAddScalarFloatModule_basic",
    "ElementwiseAddScalarInt64Module_basic",
    "ElementwiseAddScalarIntModule_basic",
    "MobilenetV3Module_basic",
    "NativeBatchNorm1DModule_basic",
    "NativeBatchNorm2DModule_basic",
    "NativeBatchNorm3DModule_basic",
    "NativeBatchNormNoneWeightModule_basic",
    "NativeGroupNormModule_basic",
    "ResNet18Module_basic",
    "ResNet18StaticModule_basic",
    # END tests failing due to: 'torch.aten.add.Tensor' op operand #1 must be Any Torch tensor type, but got '!torch.float'

    # ERROR: 'torch.aten.add.Tensor' op operand #1 must be Any Torch tensor type, but got '!torch.int'
    "ElementwiseAddScalar_TensorLiteralInt32_Module_basic",
    "HBC_basic",

    # ERROR: 'torch.aten.div.Tensor' op operand #1 must be Any Torch tensor type, but got '!torch.float'
```