### PR TITLE
Enable ResNext

### DIFF
--- a/projects/pt1/e2e_testing/main.py
+++ b/projects/pt1/e2e_testing/main.py
@@ -113,10 +113,16 @@ Available options:
                         default=False,
                         action="store_true",
                         help="Enable debug timings collection.")
+    parser.add_argument("--aten-transform",
+                        default=False,
+                        action="store_true",
+                        help="Replace aten.add.Tensor aten.add.Scalar, for ResNet like models.")
     return parser
 
 def main():
     args = _get_argparse().parse_args()
+    if args.aten_transform:
+        args.dump.append("aten-transform")
     opts = TestOptions(dumps=args.dump, use_kernels=args.use_kernels, debug_timer=args.enable_timer)
 
     all_test_unique_names = set(

--- a/projects/pt1/python/torch_mlir_e2e_test/framework.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/framework.py
@@ -167,7 +167,7 @@ class DebugTimer:
 class TestOptions:
     """Test run options."""
 
-    dump_choices = ["all", "fx-graph", "torch-mlir", "linalg-mlir", "llvm-mlir", "torch-mlir-lowering", "linalg-mlir-lowering", "obj"]
+    dump_choices = ["all", "fx-graph", "aten-transform", "torch-mlir", "linalg-mlir", "llvm-mlir", "torch-mlir-lowering", "linalg-mlir-lowering", "obj"]
 
     def __init__(self, *, dumps: List[str] = [], use_kernels=False, debug_timer=False, use_omp=True):
         self.dumps = {opt for opt in dumps}
@@ -176,7 +176,10 @@ class TestOptions:
         self.use_omp = use_omp
 
     def is_dump_enabled(self, dump: str):
-        return dump in self.dumps or "all" in self.dumps
+        if dump != "aten-transform":
+            return dump in self.dumps or "all" in self.dumps
+        else:
+            return dump in self.dumps
 
     def is_debug_timer_enabled(self):
         return self.debug_timer

--- a/projects/pt1/python/torch_mlir_e2e_test/test_suite/vision_models.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/test_suite/vision_models.py
@@ -105,3 +105,17 @@ class MobilenetV3Module(torch.nn.Module):
 @register_test_case(module_factory=lambda: MobilenetV3Module())
 def MobilenetV3Module_basic(module, tu: TestUtils):
     module.forward(tu.rand(1, 3, 224, 224))
+
+
+def ResNext():
+    model = models.resnext50_32x4d()
+    model.eval()
+    return model
+
+@register_test_case(module_factory=lambda: ResNext())
+def ResNext_basic(module, tu: TestUtils):
+    # out = module.forward(tu.randint(1, 11, high=13000))
+    out = module.forward(tu.rand(1, 3, 224, 224))
+    # model.forward(input_ids=input_ids.input_ids, attention_mask=input_ids.attention_mask, output_hidden_states=False, use_cache=False)
+    # print("gen tokens: ", gen_tokens)
+    return out


### PR DESCRIPTION
This PR will enable `ResNext`. 

Currently it's failing on this error, the generated IR is trying to add a float with a tensor:

```bash
in shape:  torch.Size([1, 128, 128])
 w shape:  (8192, 16384)
 b shape:  (8192,)
golden_trace: elapsed 30.9120 ms
Compiling ResNext_basic...
compile: elapsed 24.1077 ms
Running ResNext_basic...
============transform============
node:  add args:  (_to_copy_1, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul args:  (reciprocal, 1)
node:  add_2 args:  (_to_copy_3, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_3 args:  (reciprocal_1, 1)
node:  add_4 args:  (_to_copy_5, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_6 args:  (reciprocal_2, 1)
node:  add_6 args:  (_to_copy_7, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_9 args:  (reciprocal_3, 1)
node:  add_8 args:  (_to_copy_9, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_12 args:  (reciprocal_4, 1)
node:  add_11 args:  (_to_copy_11, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_15 args:  (reciprocal_5, 1)
node:  add_13 args:  (_to_copy_13, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_18 args:  (reciprocal_6, 1)
node:  add_15 args:  (_to_copy_15, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_21 args:  (reciprocal_7, 1)
node:  add_18 args:  (_to_copy_17, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_24 args:  (reciprocal_8, 1)
node:  add_20 args:  (_to_copy_19, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_27 args:  (reciprocal_9, 1)
node:  add_22 args:  (_to_copy_21, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_30 args:  (reciprocal_10, 1)
node:  add_25 args:  (_to_copy_23, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_33 args:  (reciprocal_11, 1)
node:  add_27 args:  (_to_copy_25, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_36 args:  (reciprocal_12, 1)
node:  add_29 args:  (_to_copy_27, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_39 args:  (reciprocal_13, 1)
node:  add_31 args:  (_to_copy_29, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_42 args:  (reciprocal_14, 1)
node:  add_34 args:  (_to_copy_31, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_45 args:  (reciprocal_15, 1)
node:  add_36 args:  (_to_copy_33, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_48 args:  (reciprocal_16, 1)
node:  add_38 args:  (_to_copy_35, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_51 args:  (reciprocal_17, 1)
node:  add_41 args:  (_to_copy_37, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_54 args:  (reciprocal_18, 1)
node:  add_43 args:  (_to_copy_39, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_57 args:  (reciprocal_19, 1)
node:  add_45 args:  (_to_copy_41, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_60 args:  (reciprocal_20, 1)
node:  add_48 args:  (_to_copy_43, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_63 args:  (reciprocal_21, 1)
node:  add_50 args:  (_to_copy_45, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_66 args:  (reciprocal_22, 1)
node:  add_52 args:  (_to_copy_47, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_69 args:  (reciprocal_23, 1)
node:  add_55 args:  (_to_copy_49, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_72 args:  (reciprocal_24, 1)
node:  add_57 args:  (_to_copy_51, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_75 args:  (reciprocal_25, 1)
node:  add_59 args:  (_to_copy_53, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_78 args:  (reciprocal_26, 1)
node:  add_61 args:  (_to_copy_55, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_81 args:  (reciprocal_27, 1)
node:  add_64 args:  (_to_copy_57, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_84 args:  (reciprocal_28, 1)
node:  add_66 args:  (_to_copy_59, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_87 args:  (reciprocal_29, 1)
node:  add_68 args:  (_to_copy_61, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_90 args:  (reciprocal_30, 1)
node:  add_71 args:  (_to_copy_63, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_93 args:  (reciprocal_31, 1)
node:  add_73 args:  (_to_copy_65, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_96 args:  (reciprocal_32, 1)
node:  add_75 args:  (_to_copy_67, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_99 args:  (reciprocal_33, 1)
node:  add_78 args:  (_to_copy_69, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_102 args:  (reciprocal_34, 1)
node:  add_80 args:  (_to_copy_71, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_105 args:  (reciprocal_35, 1)
node:  add_82 args:  (_to_copy_73, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_108 args:  (reciprocal_36, 1)
node:  add_85 args:  (_to_copy_75, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_111 args:  (reciprocal_37, 1)
node:  add_87 args:  (_to_copy_77, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_114 args:  (reciprocal_38, 1)
node:  add_89 args:  (_to_copy_79, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_117 args:  (reciprocal_39, 1)
node:  add_92 args:  (_to_copy_81, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_120 args:  (reciprocal_40, 1)
node:  add_94 args:  (_to_copy_83, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_123 args:  (reciprocal_41, 1)
node:  add_96 args:  (_to_copy_85, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_126 args:  (reciprocal_42, 1)
node:  add_99 args:  (_to_copy_87, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_129 args:  (reciprocal_43, 1)
node:  add_101 args:  (_to_copy_89, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_132 args:  (reciprocal_44, 1)
node:  add_103 args:  (_to_copy_91, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_135 args:  (reciprocal_45, 1)
node:  add_105 args:  (_to_copy_93, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_138 args:  (reciprocal_46, 1)
node:  add_108 args:  (_to_copy_95, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_141 args:  (reciprocal_47, 1)
node:  add_110 args:  (_to_copy_97, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_144 args:  (reciprocal_48, 1)
node:  add_112 args:  (_to_copy_99, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_147 args:  (reciprocal_49, 1)
node:  add_115 args:  (_to_copy_101, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_150 args:  (reciprocal_50, 1)
node:  add_117 args:  (_to_copy_103, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_153 args:  (reciprocal_51, 1)
node:  add_119 args:  (_to_copy_105, 1e-05)  kwargs:  {}
argtypes:  <class 'torch.fx.node.Node'> <class 'float'>
node:  mul_156 args:  (reciprocal_52, 1)
============transform============
JIT: elapsed 834.6772 ms
CpuProtoLinalgOnTensorsBackend.compile(): elapsed 1628.0376 ms
Backend.compile(): elapsed 1628.0412 ms
CpuProtoLinalgOnTensorsBackend.load(): elapsed 247.0402 ms
Backend.load(): elapsed 247.0436 ms
recursively_convert_to_numpy: elapsed 0.0644 ms
refbackend.invoke() args conversion: elapsed 10.7707 ms
ExecutionEngine.invoke(): elapsed 803.8791 ms
refine_result_type: elapsed 0.0038 ms
TorchDynamoTestConfig.run(): elapsed 3536.4465 ms
run: elapsed 3536.4762 ms
FAIL - "ResNext_basic"

Unexpected outcome summary: (cpuproto)

****** Failed tests - 1 tests
    FAIL - "ResNext_basic"
        @ trace item #0 - call to "forward"
        @ output of call to "forward"
        ERROR: value (Tensor with shape=[1, 1000], dtype=torch.float32, min=-0.0937, max=+0.1053, mean=+0.0009133) is not close to golden value (Tensor with shape=[1, 1000], dtype=torch.float32, min=-0.07969, max=+0.1045, mean=-2.058e-06)


Summary:
    Failed: 1
```

This is a WIP.