### PR TITLE
Fix numpy for compatibility with torchvision

### DIFF
--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy < 2.0.0
 pybind11
 wheel
 setuptools


### PR DESCRIPTION
The current `build-requirements.txt` installs the pre-release version of `numpy (2.0.0b1)`. 
But that is not compatible with the `torchvision==0.18.0.dev20240318` build. 
So we are setting numpy version to `numpy < 2.0.0`