### PR TITLE
Add --aten-transform flag to the command line args

### DIFF
--- a/projects/pt1/e2e_testing/main.py
+++ b/projects/pt1/e2e_testing/main.py
@@ -113,10 +113,16 @@ Available options:
                         default=False,
                         action="store_true",
                         help="Enable debug timings collection.")
+    parser.add_argument("--aten-transform",
+                        default=False,
+                        action="store_true",
+                        help="Replace aten.add.Tensor aten.add.Scalar, for ResNet like models.")
     return parser
 
 def main():
     args = _get_argparse().parse_args()
+    if args.aten_transform:
+        args.dump.append("aten-transform")
     opts = TestOptions(dumps=args.dump, use_kernels=args.use_kernels, debug_timer=args.enable_timer)
 
     all_test_unique_names = set(

--- a/projects/pt1/python/torch_mlir_e2e_test/framework.py
+++ b/projects/pt1/python/torch_mlir_e2e_test/framework.py
@@ -167,7 +167,7 @@ class DebugTimer:
 class TestOptions:
     """Test run options."""
 
-    dump_choices = ["all", "fx-graph", "torch-mlir", "linalg-mlir", "llvm-mlir", "torch-mlir-lowering", "linalg-mlir-lowering", "obj"]
+    dump_choices = ["all", "fx-graph", "aten-transform", "torch-mlir", "linalg-mlir", "llvm-mlir", "torch-mlir-lowering", "linalg-mlir-lowering", "obj"]
 
     def __init__(self, *, dumps: List[str] = [], use_kernels=False, debug_timer=False, use_omp=True):
         self.dumps = {opt for opt in dumps}
@@ -176,7 +176,10 @@ class TestOptions:
         self.use_omp = use_omp
 
     def is_dump_enabled(self, dump: str):
-        return dump in self.dumps or "all" in self.dumps
+        if dump != "aten-transform":
+            return dump in self.dumps or "all" in self.dumps
+        else:
+            return dump in self.dumps
 
     def is_debug_timer_enabled(self):
         return self.debug_timer


### PR DESCRIPTION
The transform operation (replacing `aten.add.Tensor` with `aten.add.Scalar`) is only requires when we are testing with `ResNet` like models. But in other cases, we might not need them.

Therefore we are adding a new flag `--aten-transform` to enable/disable this transformation in the command line. 
The flag will also dump corresponding IR files if enabled.